### PR TITLE
[Feat] Account 삭제 API 구현

### DIFF
--- a/back/src/main/java/travelRepo/domain/account/controller/AccountController.java
+++ b/back/src/main/java/travelRepo/domain/account/controller/AccountController.java
@@ -44,7 +44,8 @@ public class AccountController {
     }
 
     @DeleteMapping
-    public void accountRemove() {
+    public void accountRemove(@LoginAccountId Long loginAccountId) {
+        accountService.removeAccount(loginAccountId);
     }
 
     @GetMapping("/{accountId}")

--- a/back/src/main/java/travelRepo/domain/account/service/AccountService.java
+++ b/back/src/main/java/travelRepo/domain/account/service/AccountService.java
@@ -4,10 +4,16 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import travelRepo.domain.account.dto.AccountModifyReq;
 import travelRepo.domain.account.dto.AccountAddReq;
+import travelRepo.domain.account.dto.AccountModifyReq;
 import travelRepo.domain.account.entity.Account;
 import travelRepo.domain.account.repository.AccountRepository;
+import travelRepo.domain.board.repository.BoardPhotoRepository;
+import travelRepo.domain.board.repository.BoardRepository;
+import travelRepo.domain.board.repository.BoardTagRepository;
+import travelRepo.domain.comment.repository.CommentRepository;
+import travelRepo.domain.follow.repository.FollowRepository;
+import travelRepo.domain.likes.likesRepository.LikesRepository;
 import travelRepo.global.common.dto.IdDto;
 import travelRepo.global.exception.BusinessLogicException;
 import travelRepo.global.exception.ExceptionCode;
@@ -21,6 +27,12 @@ import java.io.IOException;
 public class AccountService {
 
     private final AccountRepository accountRepository;
+    private final BoardRepository boardRepository;
+    private final CommentRepository commentRepository;
+    private final BoardTagRepository boardTagRepository;
+    private final BoardPhotoRepository boardPhotoRepository;
+    private final FollowRepository followRepository;
+    private final LikesRepository likesRepository;
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
     private final UploadService uploadService;
 
@@ -49,6 +61,19 @@ public class AccountService {
         account.modify(modifyAccount);
 
         return new IdDto(account.getId());
+    }
+
+    @Transactional
+    public void removeAccount(Long loginAccountId) {
+
+        likesRepository.deleteByAccountId(loginAccountId);
+        commentRepository.deleteByAccountId(loginAccountId);
+        boardPhotoRepository.deleteByAccountId(loginAccountId);
+        boardTagRepository.deleteByAccountId(loginAccountId);
+        boardRepository.deleteByAccountId(loginAccountId);
+
+        followRepository.deleteByAccountId(loginAccountId);
+        accountRepository.deleteById(loginAccountId);
     }
 
     private void verifyDuplicateEmail(AccountAddReq accountAddReq) {

--- a/back/src/main/java/travelRepo/domain/board/entity/Board.java
+++ b/back/src/main/java/travelRepo/domain/board/entity/Board.java
@@ -36,6 +36,6 @@ public class Board extends BaseTime {
     @Enumerated(EnumType.STRING)
     private Category category;
 
-    @ElementCollection
-    private List<String> photos = new ArrayList<>();
+    @OneToMany(mappedBy = "board", cascade = CascadeType.PERSIST)
+    private List<BoardPhoto> boardPhotos = new ArrayList<>();
 }

--- a/back/src/main/java/travelRepo/domain/board/entity/BoardPhoto.java
+++ b/back/src/main/java/travelRepo/domain/board/entity/BoardPhoto.java
@@ -1,0 +1,23 @@
+package travelRepo.domain.board.entity;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class BoardPhoto {
+
+    @Id
+    @GeneratedValue
+    @Column(name = "boardPhoto_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "board_id")
+    private Board board;
+
+    private String photo;
+}

--- a/back/src/main/java/travelRepo/domain/board/entity/BoardTag.java
+++ b/back/src/main/java/travelRepo/domain/board/entity/BoardTag.java
@@ -8,11 +8,11 @@ import javax.persistence.*;
 @Entity
 @Getter
 @NoArgsConstructor
-public class Board_Tag {
+public class BoardTag {
 
     @Id
     @GeneratedValue
-    @Column(name = "board_tag_id")
+    @Column(name = "boardTag_id")
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/back/src/main/java/travelRepo/domain/board/entity/Tag.java
+++ b/back/src/main/java/travelRepo/domain/board/entity/Tag.java
@@ -16,7 +16,7 @@ public class Tag extends BaseTime {
 
     @Id
     @GeneratedValue
-    @Column(name = "board_id")
+    @Column(name = "tag_id")
     private Long id;
 
     private String name;

--- a/back/src/main/java/travelRepo/domain/board/repository/BoardPhotoRepository.java
+++ b/back/src/main/java/travelRepo/domain/board/repository/BoardPhotoRepository.java
@@ -1,0 +1,15 @@
+package travelRepo.domain.board.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import travelRepo.domain.board.entity.BoardPhoto;
+
+public interface BoardPhotoRepository extends JpaRepository<BoardPhoto, Long> {
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("delete from BoardPhoto boardPhoto " +
+            "where boardPhoto.board in (select board from Board board where board.account.id = :accountId)")
+    void deleteByAccountId(@Param("accountId") Long accountId);
+}

--- a/back/src/main/java/travelRepo/domain/board/repository/BoardRepository.java
+++ b/back/src/main/java/travelRepo/domain/board/repository/BoardRepository.java
@@ -1,0 +1,14 @@
+package travelRepo.domain.board.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import travelRepo.domain.board.entity.Board;
+
+public interface BoardRepository extends JpaRepository<Board, Long> {
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("delete from Board board where board.account.id = :accountId")
+    void deleteByAccountId(@Param("accountId") Long accountId);
+}

--- a/back/src/main/java/travelRepo/domain/board/repository/BoardTagRepository.java
+++ b/back/src/main/java/travelRepo/domain/board/repository/BoardTagRepository.java
@@ -1,0 +1,15 @@
+package travelRepo.domain.board.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import travelRepo.domain.board.entity.BoardTag;
+
+public interface BoardTagRepository extends JpaRepository<BoardTag, Long> {
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("delete from BoardTag boardTag where boardTag.board " +
+            "in (select board from Board board where board.account.id = :accountId)")
+    void deleteByAccountId(@Param("accountId") Long accountId);
+}

--- a/back/src/main/java/travelRepo/domain/comment/repository/CommentRepository.java
+++ b/back/src/main/java/travelRepo/domain/comment/repository/CommentRepository.java
@@ -1,0 +1,15 @@
+package travelRepo.domain.comment.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import travelRepo.domain.comment.entity.Comment;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("delete from Comment comment where comment.account.id = :accountId " +
+            "or comment.board in (select board from Board board where board.account.id = :accountId)")
+    void deleteByAccountId(@Param("accountId") Long accountId);
+}

--- a/back/src/main/java/travelRepo/domain/follow/repository/FollowRepository.java
+++ b/back/src/main/java/travelRepo/domain/follow/repository/FollowRepository.java
@@ -1,0 +1,15 @@
+package travelRepo.domain.follow.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import travelRepo.domain.follow.entity.Follow;
+
+public interface FollowRepository extends JpaRepository<Follow, Long> {
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("delete from Follow follow " +
+            "where follow.follower.id = :accountId or follow.following.id = :accountId")
+    void deleteByAccountId(@Param("accountId") Long accountId);
+}

--- a/back/src/main/java/travelRepo/domain/likes/likesRepository/LikesRepository.java
+++ b/back/src/main/java/travelRepo/domain/likes/likesRepository/LikesRepository.java
@@ -1,0 +1,15 @@
+package travelRepo.domain.likes.likesRepository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import travelRepo.domain.likes.entity.Likes;
+
+public interface LikesRepository extends JpaRepository<Likes, Long> {
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("delete from Likes likes where likes.account.id = :accountId " +
+            "or likes.board in (select board from Board board where board.account.id = :accountId)")
+    void deleteByAccountId(@Param("accountId") Long accountId);
+}

--- a/back/src/main/resources/static/db/data.sql
+++ b/back/src/main/resources/static/db/data.sql
@@ -1,1 +1,34 @@
-INSERT INTO Account(account_id, createdAt, modifiedAt, email, nickname, password, profile, role) VALUES('10001', '2022-10-14 17:13:10', '2022-10-14 17:13:10', 'test1@test.com', 'testNickname1', '$2a$10$VV8asUWpBQ0lIiagxkfcwuG3vLzwsRxLroRBtlH/VVu1TRIfppFfq', 'test/path', 'USER');
+INSERT INTO Account(account_id, createdAt, modifiedAt, email, intro, nickname, password, profile, role) VALUES('10001', '2022-10-14 10:00:01', '2022-10-14 10:00:01', 'test1@test.com', 'testIntro', 'testNickname1', '$2a$10$.s16a34pwL.M9NksIVSkIOasWPPsBB39blD1lOqinqhzoR7ri84d.', 'https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg', 'USER');
+INSERT INTO Account(account_id, createdAt, modifiedAt, email, intro, nickname, password, profile, role) VALUES('10002', '2022-10-14 10:00:02', '2022-10-14 10:00:02', 'test2@test.com', 'testIntro', 'testNickname2', '$2a$10$.s16a34pwL.M9NksIVSkIOasWPPsBB39blD1lOqinqhzoR7ri84d.', 'https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg', 'USER');
+INSERT INTO Account(account_id, createdAt, modifiedAt, email, intro, nickname, password, profile, role) VALUES('10003', '2022-10-14 10:00:03', '2022-10-14 10:00:03', 'test3@test.com', 'testIntro', 'testNickname3', '$2a$10$.s16a34pwL.M9NksIVSkIOasWPPsBB39blD1lOqinqhzoR7ri84d.', 'https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg', 'USER');
+
+INSERT INTO Follow(follow_id, createdAt, modifiedAt, follower_id, following_id) VALUES('11001', '2022-10-14 11:00:01', '2022-10-14 11:00:01', '10001', '10002');
+INSERT INTO Follow(follow_id, createdAt, modifiedAt, follower_id, following_id) VALUES('11002', '2022-10-14 11:00:01', '2022-10-14 11:00:01', '10001', '10003');
+INSERT INTO Follow(follow_id, createdAt, modifiedAt, follower_id, following_id) VALUES('11003', '2022-10-14 11:00:01', '2022-10-14 11:00:01', '10002', '10001');
+
+INSERT INTO Board(board_id, createdAt, modifiedAt, category, content, likeCount, location, title, views, account_id) VALUES('12001', '2022-10-14 12:00:01', '2022-10-14 12:00:01', 'RESTAURANT', 'testContents', '1', 'test-location', 'testTitle', '10', '10001');
+INSERT INTO Board(board_id, createdAt, modifiedAt, category, content, likeCount, location, title, views, account_id) VALUES('12002', '2022-10-14 12:00:02', '2022-10-14 12:00:02', 'SPOT', 'testContents', '3', 'test-location', 'testTitle', '10', '10002');
+INSERT INTO Board(board_id, createdAt, modifiedAt, category, content, likeCount, location, title, views, account_id) VALUES('12003', '2022-10-14 12:00:03', '2022-10-14 12:00:03', 'STAY', 'testContents', '1', 'test-location', 'testTitle', '10', '10003');
+
+INSERT INTO BoardPhoto(boardPhoto_id, board_id, photo) VALUES('13001', '12001', 'https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg');
+INSERT INTO BoardPhoto(boardPhoto_id, board_id, photo) VALUES('13002', '12001', 'https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg');
+INSERT INTO BoardPhoto(boardPhoto_id, board_id, photo) VALUES('13003', '12001', 'https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg');
+INSERT INTO BoardPhoto(boardPhoto_id, board_id, photo) VALUES('13004', '12002', 'https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg');
+INSERT INTO BoardPhoto(boardPhoto_id, board_id, photo) VALUES('13005', '12003', 'https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg');
+
+INSERT INTO Likes(likes_id, createdAt, modifiedAt, account_id, board_id) VALUES('14001', '2022-10-14 13:00:01', '2022-10-14 13:00:01', '10002', '12001');
+INSERT INTO Likes(likes_id, createdAt, modifiedAt, account_id, board_id) VALUES('14002', '2022-10-14 13:00:02', '2022-10-14 13:00:02', '10001', '12002');
+INSERT INTO Likes(likes_id, createdAt, modifiedAt, account_id, board_id) VALUES('14003', '2022-10-14 13:00:03', '2022-10-14 13:00:03', '10002', '12002');
+INSERT INTO Likes(likes_id, createdAt, modifiedAt, account_id, board_id) VALUES('14004', '2022-10-14 13:00:04', '2022-10-14 13:00:04', '10003', '12002');
+INSERT INTO Likes(likes_id, createdAt, modifiedAt, account_id, board_id) VALUES('14005', '2022-10-14 13:00:05', '2022-10-14 13:00:05', '10001', '12003');
+
+INSERT INTO Comment(comment_id, createdAt, modifiedAt, content, account_id, board_id) VALUES('15001', '2022-10-14 14:00:01', '2022-10-14 14:00:01', 'testContents', '10001', '12002');
+INSERT INTO Comment(comment_id, createdAt, modifiedAt, content, account_id, board_id) VALUES('15002', '2022-10-14 14:00:01', '2022-10-14 14:00:01', 'testContents', '10001', '12003');
+INSERT INTO Comment(comment_id, createdAt, modifiedAt, content, account_id, board_id) VALUES('15003', '2022-10-14 14:00:01', '2022-10-14 14:00:01', 'testContents', '10002', '12001');
+
+INSERT INTO Tag(tag_id, createdAt, modifiedAt, name) VALUES('16001', '2022-10-14 15:00:01', '2022-10-14 14:00:01', 'testName1');
+INSERT INTO Tag(tag_id, createdAt, modifiedAt, name) VALUES('16002', '2022-10-14 15:00:02', '2022-10-14 15:00:02', 'testName2');
+INSERT INTO Tag(tag_id, createdAt, modifiedAt, name) VALUES('16003', '2022-10-14 15:00:03', '2022-10-14 15:00:03', 'testName3');
+
+INSERT INTO BoardTag(boardTag_id, board_id, tag_id) VALUES('17001', '12001', '16001');
+INSERT INTO BoardTag(boardTag_id, board_id, tag_id) VALUES('17002', '12001', '16002');

--- a/back/src/main/resources/static/docs/index.html
+++ b/back/src/main/resources/static/docs/index.html
@@ -522,20 +522,20 @@ Host: localhost:8080
 <thead>
 <tr>
 <th class="tableblock halign-left valign-top">Path</th>
-<th class="tableblock halign-left valign-top">Type</th>
 <th class="tableblock halign-left valign-top">Description</th>
+<th class="tableblock halign-left valign-top">Required</th>
 </tr>
 </thead>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>email</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">이메일</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code><strong>true</strong></code></p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>password</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">비밀번호</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code><strong>true</strong></code></p></td>
 </tr>
 </tbody>
 </table>
@@ -546,7 +546,7 @@ Host: localhost:8080
 Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjgzMjc4MTMsImV4cCI6MTY2ODMzMTQxM30.r3L46pyfzhhbOhhoT5f8ntnYOfOn3mlYctiR3x1mwB0
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjgzODg2MDgsImV4cCI6MTY2ODM5MjIwOH0.RO4o_y17KTFGUMasiRTE0LqBqAUm7ixp-0OLcW3RWhY
 X-Content-Type-Options: nosniff
 X-XSS-Protection: 1; mode=block
 Cache-Control: no-cache, no-store, max-age=0, must-revalidate
@@ -621,46 +621,54 @@ Content-Type: image/jpeg
 <table class="tableblock frame-all grid-all stretch">
 <caption class="title">Table 3. request-parts</caption>
 <colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
 </colgroup>
 <thead>
 <tr>
 <th class="tableblock halign-left valign-top">Part</th>
 <th class="tableblock halign-left valign-top">Description</th>
+<th class="tableblock halign-left valign-top">Required</th>
 </tr>
 </thead>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>profile</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">프로필 이미지</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code><strong>true</strong></code></p></td>
 </tr>
 </tbody>
 </table>
 <table class="tableblock frame-all grid-all stretch">
 <caption class="title">Table 4. request-parameters</caption>
 <colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
 </colgroup>
 <thead>
 <tr>
 <th class="tableblock halign-left valign-top">Parameter</th>
 <th class="tableblock halign-left valign-top">Description</th>
+<th class="tableblock halign-left valign-top">Required</th>
 </tr>
 </thead>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>email</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">이메일</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code><strong>true</strong></code></p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>password</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">비밀 번호</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code><strong>true</strong></code></p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>nickname</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">닉네임</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code><strong>true</strong></code></p></td>
 </tr>
 </tbody>
 </table>
@@ -713,30 +721,35 @@ Content-Length: 14
 <div class="listingblock">
 <div class="title">curl-request</div>
 <div class="content">
-<pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/accounts/10001' -i -X POST \
+<pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/accounts/modify' -i -X POST \
     -H 'Content-Type: multipart/form-data;charset=UTF-8' \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjgzMjc4MTIsImV4cCI6MTY2ODMzMTQxMn0.qE9bCqR6Xx7H8pjcgUegePoZAiRZsYW5z3ENEHsxw58' \
+    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjgzODg2MDgsImV4cCI6MTY2ODM5MjIwOH0.RO4o_y17KTFGUMasiRTE0LqBqAUm7ixp-0OLcW3RWhY' \
     -F 'profile=@profile.jpeg;type=image/jpeg' \
-    -F 'password=123456' \
-    -F 'nickname=testNickname'</code></pre>
+    -F 'password=123456789' \
+    -F 'nickname=modifyTestNickname' \
+    -F 'intro=modifyTestIntro'</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">http-request</div>
 <div class="content">
-<pre class="prettyprint highlight nowrap"><code data-lang="http">POST /accounts/10001 HTTP/1.1
+<pre class="prettyprint highlight nowrap"><code data-lang="http">POST /accounts/modify HTTP/1.1
 Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjgzMjc4MTIsImV4cCI6MTY2ODMzMTQxMn0.qE9bCqR6Xx7H8pjcgUegePoZAiRZsYW5z3ENEHsxw58
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjgzODg2MDgsImV4cCI6MTY2ODM5MjIwOH0.RO4o_y17KTFGUMasiRTE0LqBqAUm7ixp-0OLcW3RWhY
 Host: localhost:8080
 
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
 Content-Disposition: form-data; name=password
 
-123456
+123456789
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
 Content-Disposition: form-data; name=nickname
 
-testNickname
+modifyTestNickname
+--6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
+Content-Disposition: form-data; name=intro
+
+modifyTestIntro
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
 Content-Disposition: form-data; name=profile; filename=profile.jpeg
 Content-Type: image/jpeg
@@ -748,80 +761,76 @@ Content-Type: image/jpeg
 <table class="tableblock frame-all grid-all stretch">
 <caption class="title">Table 6. request-headers</caption>
 <colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
 </colgroup>
 <thead>
 <tr>
 <th class="tableblock halign-left valign-top">Name</th>
 <th class="tableblock halign-left valign-top">Description</th>
+<th class="tableblock halign-left valign-top">Required</th>
 </tr>
 </thead>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">JWT</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code><strong>true</strong></code></p></td>
 </tr>
 </tbody>
 </table>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 7. /accounts/{accountId}</caption>
+<caption class="title">Table 7. request-parts</caption>
 <colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Parameter</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>accountId</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Account 식별자</p></td>
-</tr>
-</tbody>
-</table>
-<table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 8. request-parts</caption>
-<colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
 </colgroup>
 <thead>
 <tr>
 <th class="tableblock halign-left valign-top">Part</th>
 <th class="tableblock halign-left valign-top">Description</th>
+<th class="tableblock halign-left valign-top">Required</th>
 </tr>
 </thead>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>profile</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">프로필 이미지</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>false</code></p></td>
 </tr>
 </tbody>
 </table>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 9. request-parameters</caption>
+<caption class="title">Table 8. request-parameters</caption>
 <colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
 </colgroup>
 <thead>
 <tr>
 <th class="tableblock halign-left valign-top">Parameter</th>
 <th class="tableblock halign-left valign-top">Description</th>
+<th class="tableblock halign-left valign-top">Required</th>
 </tr>
 </thead>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>password</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">비밀 번호</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>false</code></p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>nickname</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">닉네임</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>false</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>intro</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">소개글</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>false</code></p></td>
 </tr>
 </tbody>
 </table>
@@ -847,7 +856,7 @@ Content-Length: 18
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 10. response-fields</caption>
+<caption class="title">Table 9. response-fields</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -875,17 +884,39 @@ Content-Length: 18
 <div class="title">curl-request</div>
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/accounts' -i -X DELETE \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjgzMjc4MTIsImV4cCI6MTY2ODMzMTQxMn0.qE9bCqR6Xx7H8pjcgUegePoZAiRZsYW5z3ENEHsxw58'</code></pre>
+    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjgzODg2MDcsImV4cCI6MTY2ODM5MjIwN30.X1WO7uyzRD6iZr_3wS-jWz7NQ2QcoLDfhVXmeAkWgwU'</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">http-request</div>
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">DELETE /accounts HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjgzMjc4MTIsImV4cCI6MTY2ODMzMTQxMn0.qE9bCqR6Xx7H8pjcgUegePoZAiRZsYW5z3ENEHsxw58
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjgzODg2MDcsImV4cCI6MTY2ODM5MjIwN30.X1WO7uyzRD6iZr_3wS-jWz7NQ2QcoLDfhVXmeAkWgwU
 Host: localhost:8080</code></pre>
 </div>
 </div>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 10. request-headers</caption>
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Description</th>
+<th class="tableblock halign-left valign-top">Required</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">JWT</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code><strong>true</strong></code></p></td>
+</tr>
+</tbody>
+</table>
 <div class="listingblock">
 <div class="title">http-response</div>
 <div class="content">
@@ -907,32 +938,35 @@ X-Frame-Options: DENY</code></pre>
 <div class="listingblock">
 <div class="title">curl-request</div>
 <div class="content">
-<pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/accounts/2' -i -X GET</code></pre>
+<pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/accounts/10002' -i -X GET</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">http-request</div>
 <div class="content">
-<pre class="prettyprint highlight nowrap"><code data-lang="http">GET /accounts/2 HTTP/1.1
+<pre class="prettyprint highlight nowrap"><code data-lang="http">GET /accounts/10002 HTTP/1.1
 Host: localhost:8080</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
 <caption class="title">Table 11. /accounts/{accountId}</caption>
 <colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
 </colgroup>
 <thead>
 <tr>
 <th class="tableblock halign-left valign-top">Parameter</th>
 <th class="tableblock halign-left valign-top">Description</th>
+<th class="tableblock halign-left valign-top">Required</th>
 </tr>
 </thead>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>accountId</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Account 식별자</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code><strong>true</strong></code></p></td>
 </tr>
 </tbody>
 </table>
@@ -950,10 +984,10 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 170
+Content-Length: 166
 
 {
-  "id" : 10001,
+  "id" : 1,
   "email" : "mock@mock.com",
   "nickname" : "mockNickname",
   "intro" : "mockIntro",
@@ -1022,33 +1056,36 @@ Content-Length: 170
 <div class="title">curl-request</div>
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/accounts/login' -i -X GET \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjgzMjc4MTIsImV4cCI6MTY2ODMzMTQxMn0.qE9bCqR6Xx7H8pjcgUegePoZAiRZsYW5z3ENEHsxw58'</code></pre>
+    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjgzODg2MDgsImV4cCI6MTY2ODM5MjIwOH0.RO4o_y17KTFGUMasiRTE0LqBqAUm7ixp-0OLcW3RWhY'</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">http-request</div>
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">GET /accounts/login HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjgzMjc4MTIsImV4cCI6MTY2ODMzMTQxMn0.qE9bCqR6Xx7H8pjcgUegePoZAiRZsYW5z3ENEHsxw58
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjgzODg2MDgsImV4cCI6MTY2ODM5MjIwOH0.RO4o_y17KTFGUMasiRTE0LqBqAUm7ixp-0OLcW3RWhY
 Host: localhost:8080</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
 <caption class="title">Table 13. request-headers</caption>
 <colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
 </colgroup>
 <thead>
 <tr>
 <th class="tableblock halign-left valign-top">Name</th>
 <th class="tableblock halign-left valign-top">Description</th>
+<th class="tableblock halign-left valign-top">Required</th>
 </tr>
 </thead>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">JWT</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code><strong>true</strong></code></p></td>
 </tr>
 </tbody>
 </table>
@@ -1066,10 +1103,10 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 170
+Content-Length: 166
 
 {
-  "id" : 10001,
+  "id" : 1,
   "email" : "mock@mock.com",
   "nickname" : "mockNickname",
   "intro" : "mockIntro",
@@ -1137,84 +1174,96 @@ Content-Length: 170
 <div class="listingblock">
 <div class="title">curl-request</div>
 <div class="content">
-<pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/accounts/follow/2?page=2&amp;size=5&amp;sort=createdAt%2Cdesc&amp;status=following' -i -X GET \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjgzMjc4MTIsImV4cCI6MTY2ODMzMTQxMn0.qE9bCqR6Xx7H8pjcgUegePoZAiRZsYW5z3ENEHsxw58'</code></pre>
+<pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/accounts/follow/10002?page=2&amp;size=5&amp;sort=createdAt%2Cdesc&amp;status=following' -i -X GET \
+    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjgzODg2MDgsImV4cCI6MTY2ODM5MjIwOH0.RO4o_y17KTFGUMasiRTE0LqBqAUm7ixp-0OLcW3RWhY'</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">http-request</div>
 <div class="content">
-<pre class="prettyprint highlight nowrap"><code data-lang="http">GET /accounts/follow/2?page=2&amp;size=5&amp;sort=createdAt%2Cdesc&amp;status=following HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjgzMjc4MTIsImV4cCI6MTY2ODMzMTQxMn0.qE9bCqR6Xx7H8pjcgUegePoZAiRZsYW5z3ENEHsxw58
+<pre class="prettyprint highlight nowrap"><code data-lang="http">GET /accounts/follow/10002?page=2&amp;size=5&amp;sort=createdAt%2Cdesc&amp;status=following HTTP/1.1
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjgzODg2MDgsImV4cCI6MTY2ODM5MjIwOH0.RO4o_y17KTFGUMasiRTE0LqBqAUm7ixp-0OLcW3RWhY
 Host: localhost:8080</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
 <caption class="title">Table 15. request-headers</caption>
 <colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
 </colgroup>
 <thead>
 <tr>
 <th class="tableblock halign-left valign-top">Name</th>
 <th class="tableblock halign-left valign-top">Description</th>
+<th class="tableblock halign-left valign-top">Required</th>
 </tr>
 </thead>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">JWT</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>false</code></p></td>
 </tr>
 </tbody>
 </table>
 <table class="tableblock frame-all grid-all stretch">
 <caption class="title">Table 16. /accounts/follow/{accountId}</caption>
 <colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
 </colgroup>
 <thead>
 <tr>
 <th class="tableblock halign-left valign-top">Parameter</th>
 <th class="tableblock halign-left valign-top">Description</th>
+<th class="tableblock halign-left valign-top">Required</th>
 </tr>
 </thead>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>accountId</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Account 식별자</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code><strong>true</strong></code></p></td>
 </tr>
 </tbody>
 </table>
 <table class="tableblock frame-all grid-all stretch">
 <caption class="title">Table 17. request-parameters</caption>
 <colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
 </colgroup>
 <thead>
 <tr>
 <th class="tableblock halign-left valign-top">Parameter</th>
 <th class="tableblock halign-left valign-top">Description</th>
+<th class="tableblock halign-left valign-top">Required</th>
 </tr>
 </thead>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>page</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">페이지 번호(default = 1)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>false</code></p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>size</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">페이징 크기(default = 10)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>false</code></p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>sort</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">정렬 조건(default = asc)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>false</code></p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>status</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">following 또는 follower</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code><strong>true</strong></code></p></td>
 </tr>
 </tbody>
 </table>
@@ -1232,13 +1281,13 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 3149
+Content-Length: 3098
 
 {
   "content" : [ {
-    "id" : 10001,
-    "nickname" : "mockNickname10001",
-    "profile" : "/mock/path10001",
+    "id" : 1,
+    "nickname" : "mockNickname1",
+    "profile" : "/mock/path1",
     "follow" : false,
     "boards" : [ {
       "id" : 2,
@@ -1262,9 +1311,9 @@ Content-Length: 3149
       "title" : "mockTitle6"
     } ]
   }, {
-    "id" : 10007,
-    "nickname" : "mockNickname10007",
-    "profile" : "/mock/path10007",
+    "id" : 7,
+    "nickname" : "mockNickname7",
+    "profile" : "/mock/path7",
     "follow" : false,
     "boards" : [ {
       "id" : 8,
@@ -1288,9 +1337,9 @@ Content-Length: 3149
       "title" : "mockTitle12"
     } ]
   }, {
-    "id" : 10013,
-    "nickname" : "mockNickname10013",
-    "profile" : "/mock/path10013",
+    "id" : 13,
+    "nickname" : "mockNickname13",
+    "profile" : "/mock/path13",
     "follow" : false,
     "boards" : [ {
       "id" : 14,
@@ -1314,9 +1363,9 @@ Content-Length: 3149
       "title" : "mockTitle18"
     } ]
   }, {
-    "id" : 10019,
-    "nickname" : "mockNickname10019",
-    "profile" : "/mock/path10019",
+    "id" : 19,
+    "nickname" : "mockNickname19",
+    "profile" : "/mock/path19",
     "follow" : false,
     "boards" : [ {
       "id" : 20,
@@ -1340,9 +1389,9 @@ Content-Length: 3149
       "title" : "mockTitle24"
     } ]
   }, {
-    "id" : 10025,
-    "nickname" : "mockNickname10025",
-    "profile" : "/mock/path10025",
+    "id" : 25,
+    "nickname" : "mockNickname25",
+    "profile" : "/mock/path25",
     "follow" : false,
     "boards" : [ {
       "id" : 26,
@@ -1487,52 +1536,58 @@ Content-Length: 3149
 <div class="title">curl-request</div>
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/follows/2' -i -X POST \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjgzMjc4MTMsImV4cCI6MTY2ODMzMTQxM30.r3L46pyfzhhbOhhoT5f8ntnYOfOn3mlYctiR3x1mwB0'</code></pre>
+    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjgzODg2MDgsImV4cCI6MTY2ODM5MjIwOH0.RO4o_y17KTFGUMasiRTE0LqBqAUm7ixp-0OLcW3RWhY'</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">http-request</div>
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">POST /follows/2 HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjgzMjc4MTMsImV4cCI6MTY2ODMzMTQxM30.r3L46pyfzhhbOhhoT5f8ntnYOfOn3mlYctiR3x1mwB0
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjgzODg2MDgsImV4cCI6MTY2ODM5MjIwOH0.RO4o_y17KTFGUMasiRTE0LqBqAUm7ixp-0OLcW3RWhY
 Host: localhost:8080</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
 <caption class="title">Table 19. request-headers</caption>
 <colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
 </colgroup>
 <thead>
 <tr>
 <th class="tableblock halign-left valign-top">Name</th>
 <th class="tableblock halign-left valign-top">Description</th>
+<th class="tableblock halign-left valign-top">Required</th>
 </tr>
 </thead>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">JWT</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code><strong>true</strong></code></p></td>
 </tr>
 </tbody>
 </table>
 <table class="tableblock frame-all grid-all stretch">
 <caption class="title">Table 20. /follows/{accountId}</caption>
 <colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
 </colgroup>
 <thead>
 <tr>
 <th class="tableblock halign-left valign-top">Parameter</th>
 <th class="tableblock halign-left valign-top">Description</th>
+<th class="tableblock halign-left valign-top">Required</th>
 </tr>
 </thead>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>accountId</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Account 식별자</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code><strong>true</strong></code></p></td>
 </tr>
 </tbody>
 </table>
@@ -1586,52 +1641,58 @@ Content-Length: 26
 <div class="title">curl-request</div>
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/follows/2' -i -X GET \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjgzMjc4MTMsImV4cCI6MTY2ODMzMTQxM30.r3L46pyfzhhbOhhoT5f8ntnYOfOn3mlYctiR3x1mwB0'</code></pre>
+    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjgzODg2MDgsImV4cCI6MTY2ODM5MjIwOH0.RO4o_y17KTFGUMasiRTE0LqBqAUm7ixp-0OLcW3RWhY'</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">http-request</div>
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">GET /follows/2 HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjgzMjc4MTMsImV4cCI6MTY2ODMzMTQxM30.r3L46pyfzhhbOhhoT5f8ntnYOfOn3mlYctiR3x1mwB0
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjgzODg2MDgsImV4cCI6MTY2ODM5MjIwOH0.RO4o_y17KTFGUMasiRTE0LqBqAUm7ixp-0OLcW3RWhY
 Host: localhost:8080</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
 <caption class="title">Table 22. request-headers</caption>
 <colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
 </colgroup>
 <thead>
 <tr>
 <th class="tableblock halign-left valign-top">Name</th>
 <th class="tableblock halign-left valign-top">Description</th>
+<th class="tableblock halign-left valign-top">Required</th>
 </tr>
 </thead>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">JWT</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code><strong>true</strong></code></p></td>
 </tr>
 </tbody>
 </table>
 <table class="tableblock frame-all grid-all stretch">
 <caption class="title">Table 23. /follows/{accountId}</caption>
 <colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
 </colgroup>
 <thead>
 <tr>
 <th class="tableblock halign-left valign-top">Parameter</th>
 <th class="tableblock halign-left valign-top">Description</th>
+<th class="tableblock halign-left valign-top">Required</th>
 </tr>
 </thead>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>accountId</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Account 식별자</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code><strong>true</strong></code></p></td>
 </tr>
 </tbody>
 </table>
@@ -1690,53 +1751,59 @@ Content-Length: 21
 <div class="listingblock">
 <div class="title">curl-request</div>
 <div class="content">
-<pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/likes/1010001' -i -X POST \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjgzMjc4MTMsImV4cCI6MTY2ODMzMTQxM30.r3L46pyfzhhbOhhoT5f8ntnYOfOn3mlYctiR3x1mwB0'</code></pre>
+<pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/likes/10101' -i -X POST \
+    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjgzODg2MDgsImV4cCI6MTY2ODM5MjIwOH0.RO4o_y17KTFGUMasiRTE0LqBqAUm7ixp-0OLcW3RWhY'</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">http-request</div>
 <div class="content">
-<pre class="prettyprint highlight nowrap"><code data-lang="http">POST /likes/1010001 HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjgzMjc4MTMsImV4cCI6MTY2ODMzMTQxM30.r3L46pyfzhhbOhhoT5f8ntnYOfOn3mlYctiR3x1mwB0
+<pre class="prettyprint highlight nowrap"><code data-lang="http">POST /likes/10101 HTTP/1.1
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjgzODg2MDgsImV4cCI6MTY2ODM5MjIwOH0.RO4o_y17KTFGUMasiRTE0LqBqAUm7ixp-0OLcW3RWhY
 Host: localhost:8080</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
 <caption class="title">Table 25. request-headers</caption>
 <colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
 </colgroup>
 <thead>
 <tr>
 <th class="tableblock halign-left valign-top">Name</th>
 <th class="tableblock halign-left valign-top">Description</th>
+<th class="tableblock halign-left valign-top">Required</th>
 </tr>
 </thead>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">JWT</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code><strong>true</strong></code></p></td>
 </tr>
 </tbody>
 </table>
 <table class="tableblock frame-all grid-all stretch">
 <caption class="title">Table 26. /likes/{boardId}</caption>
 <colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
 </colgroup>
 <thead>
 <tr>
 <th class="tableblock halign-left valign-top">Parameter</th>
 <th class="tableblock halign-left valign-top">Description</th>
+<th class="tableblock halign-left valign-top">Required</th>
 </tr>
 </thead>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>boardId</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Board 식별자</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code><strong>true</strong></code></p></td>
 </tr>
 </tbody>
 </table>
@@ -1789,53 +1856,59 @@ Content-Length: 26
 <div class="listingblock">
 <div class="title">curl-request</div>
 <div class="content">
-<pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/likes/1010001' -i -X GET \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjgzMjc4MTMsImV4cCI6MTY2ODMzMTQxM30.r3L46pyfzhhbOhhoT5f8ntnYOfOn3mlYctiR3x1mwB0'</code></pre>
+<pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/likes/10101' -i -X GET \
+    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjgzODg2MDgsImV4cCI6MTY2ODM5MjIwOH0.RO4o_y17KTFGUMasiRTE0LqBqAUm7ixp-0OLcW3RWhY'</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">http-request</div>
 <div class="content">
-<pre class="prettyprint highlight nowrap"><code data-lang="http">GET /likes/1010001 HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjgzMjc4MTMsImV4cCI6MTY2ODMzMTQxM30.r3L46pyfzhhbOhhoT5f8ntnYOfOn3mlYctiR3x1mwB0
+<pre class="prettyprint highlight nowrap"><code data-lang="http">GET /likes/10101 HTTP/1.1
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjgzODg2MDgsImV4cCI6MTY2ODM5MjIwOH0.RO4o_y17KTFGUMasiRTE0LqBqAUm7ixp-0OLcW3RWhY
 Host: localhost:8080</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
 <caption class="title">Table 28. request-headers</caption>
 <colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
 </colgroup>
 <thead>
 <tr>
 <th class="tableblock halign-left valign-top">Name</th>
 <th class="tableblock halign-left valign-top">Description</th>
+<th class="tableblock halign-left valign-top">Required</th>
 </tr>
 </thead>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">JWT</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code><strong>true</strong></code></p></td>
 </tr>
 </tbody>
 </table>
 <table class="tableblock frame-all grid-all stretch">
 <caption class="title">Table 29. /likes/{boardId}</caption>
 <colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
 </colgroup>
 <thead>
 <tr>
 <th class="tableblock halign-left valign-top">Parameter</th>
 <th class="tableblock halign-left valign-top">Description</th>
+<th class="tableblock halign-left valign-top">Required</th>
 </tr>
 </thead>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>boardId</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Board 식별자</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code><strong>true</strong></code></p></td>
 </tr>
 </tbody>
 </table>
@@ -1889,7 +1962,7 @@ Content-Length: 20
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2022-11-13 15:51:33 +0900
+Last updated 2022-11-14 10:11:32 +0900
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prettify/r298/prettify.min.css">

--- a/back/src/test/resources/static/db/data.sql
+++ b/back/src/test/resources/static/db/data.sql
@@ -1,2 +1,34 @@
-INSERT INTO Account(account_id, createdAt, modifiedAt, email, nickname, password, profile, role) VALUES('10001', '2022-10-14 17:13:10', '2022-10-14 17:13:10', 'test1@test.com', 'testNickname1', '$2a$10$VV8asUWpBQ0lIiagxkfcwuG3vLzwsRxLroRBtlH/VVu1TRIfppFfq', 'test/path', 'USER');
-INSERT INTO Account(account_id, createdAt, modifiedAt, email, nickname, password, profile, role) VALUES('10002', '2022-10-14 17:13:10', '2022-10-14 17:13:10', 'test2@test.com', 'testNickname2', '$2a$10$VV8asUWpBQ0lIiagxkfcwuG3vLzwsRxLroRBtlH/VVu1TRIfppFfq', 'test/path', 'USER');
+INSERT INTO Account(account_id, createdAt, modifiedAt, email, intro, nickname, password, profile, role) VALUES('10001', '2022-10-14 10:00:01', '2022-10-14 10:00:01', 'test1@test.com', 'testIntro', 'testNickname1', '$2a$10$.s16a34pwL.M9NksIVSkIOasWPPsBB39blD1lOqinqhzoR7ri84d.', 'https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg', 'USER');
+INSERT INTO Account(account_id, createdAt, modifiedAt, email, intro, nickname, password, profile, role) VALUES('10002', '2022-10-14 10:00:02', '2022-10-14 10:00:02', 'test2@test.com', 'testIntro', 'testNickname2', '$2a$10$.s16a34pwL.M9NksIVSkIOasWPPsBB39blD1lOqinqhzoR7ri84d.', 'https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg', 'USER');
+INSERT INTO Account(account_id, createdAt, modifiedAt, email, intro, nickname, password, profile, role) VALUES('10003', '2022-10-14 10:00:03', '2022-10-14 10:00:03', 'test3@test.com', 'testIntro', 'testNickname3', '$2a$10$.s16a34pwL.M9NksIVSkIOasWPPsBB39blD1lOqinqhzoR7ri84d.', 'https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg', 'USER');
+
+INSERT INTO Follow(follow_id, createdAt, modifiedAt, follower_id, following_id) VALUES('11001', '2022-10-14 11:00:01', '2022-10-14 11:00:01', '10001', '10002');
+INSERT INTO Follow(follow_id, createdAt, modifiedAt, follower_id, following_id) VALUES('11002', '2022-10-14 11:00:01', '2022-10-14 11:00:01', '10001', '10003');
+INSERT INTO Follow(follow_id, createdAt, modifiedAt, follower_id, following_id) VALUES('11003', '2022-10-14 11:00:01', '2022-10-14 11:00:01', '10002', '10001');
+
+INSERT INTO Board(board_id, createdAt, modifiedAt, category, content, likeCount, location, title, views, account_id) VALUES('12001', '2022-10-14 12:00:01', '2022-10-14 12:00:01', 'RESTAURANT', 'testContents', '1', 'test-location', 'testTitle', '10', '10001');
+INSERT INTO Board(board_id, createdAt, modifiedAt, category, content, likeCount, location, title, views, account_id) VALUES('12002', '2022-10-14 12:00:02', '2022-10-14 12:00:02', 'SPOT', 'testContents', '3', 'test-location', 'testTitle', '10', '10002');
+INSERT INTO Board(board_id, createdAt, modifiedAt, category, content, likeCount, location, title, views, account_id) VALUES('12003', '2022-10-14 12:00:03', '2022-10-14 12:00:03', 'STAY', 'testContents', '1', 'test-location', 'testTitle', '10', '10003');
+
+INSERT INTO BoardPhoto(boardPhoto_id, board_id, photo) VALUES('13001', '12001', 'https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg');
+INSERT INTO BoardPhoto(boardPhoto_id, board_id, photo) VALUES('13002', '12001', 'https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg');
+INSERT INTO BoardPhoto(boardPhoto_id, board_id, photo) VALUES('13003', '12001', 'https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg');
+INSERT INTO BoardPhoto(boardPhoto_id, board_id, photo) VALUES('13004', '12002', 'https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg');
+INSERT INTO BoardPhoto(boardPhoto_id, board_id, photo) VALUES('13005', '12003', 'https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg');
+
+INSERT INTO Likes(likes_id, createdAt, modifiedAt, account_id, board_id) VALUES('14001', '2022-10-14 13:00:01', '2022-10-14 13:00:01', '10002', '12001');
+INSERT INTO Likes(likes_id, createdAt, modifiedAt, account_id, board_id) VALUES('14002', '2022-10-14 13:00:02', '2022-10-14 13:00:02', '10001', '12002');
+INSERT INTO Likes(likes_id, createdAt, modifiedAt, account_id, board_id) VALUES('14003', '2022-10-14 13:00:03', '2022-10-14 13:00:03', '10002', '12002');
+INSERT INTO Likes(likes_id, createdAt, modifiedAt, account_id, board_id) VALUES('14004', '2022-10-14 13:00:04', '2022-10-14 13:00:04', '10003', '12002');
+INSERT INTO Likes(likes_id, createdAt, modifiedAt, account_id, board_id) VALUES('14005', '2022-10-14 13:00:05', '2022-10-14 13:00:05', '10001', '12003');
+
+INSERT INTO Comment(comment_id, createdAt, modifiedAt, content, account_id, board_id) VALUES('15001', '2022-10-14 14:00:01', '2022-10-14 14:00:01', 'testContents', '10001', '12002');
+INSERT INTO Comment(comment_id, createdAt, modifiedAt, content, account_id, board_id) VALUES('15002', '2022-10-14 14:00:01', '2022-10-14 14:00:01', 'testContents', '10001', '12003');
+INSERT INTO Comment(comment_id, createdAt, modifiedAt, content, account_id, board_id) VALUES('15003', '2022-10-14 14:00:01', '2022-10-14 14:00:01', 'testContents', '10002', '12001');
+
+INSERT INTO Tag(tag_id, createdAt, modifiedAt, name) VALUES('16001', '2022-10-14 15:00:01', '2022-10-14 14:00:01', 'testName1');
+INSERT INTO Tag(tag_id, createdAt, modifiedAt, name) VALUES('16002', '2022-10-14 15:00:02', '2022-10-14 15:00:02', 'testName2');
+INSERT INTO Tag(tag_id, createdAt, modifiedAt, name) VALUES('16003', '2022-10-14 15:00:03', '2022-10-14 15:00:03', 'testName3');
+
+INSERT INTO BoardTag(boardTag_id, board_id, tag_id) VALUES('17001', '12001', '16001');
+INSERT INTO BoardTag(boardTag_id, board_id, tag_id) VALUES('17002', '12001', '16002');


### PR DESCRIPTION
Account 삭제 API를 구현했습니다.

1. account와 연관관계에 있는 엔티티를 차례대로 삭제한 후, account를 삭제하였습니다.

2. 삭제는 bulk 연산을 통해 delete를 한번에 처리하도록 각 repository에 메서드를 작성하고 사용하였습니다. 

추가 변경
1. Board를 삭제할 때 photo가 삭제되지 않는 문제가 있어서 JoinTable역할을 할 BoardPhoto를 생성하였습니다.

2. Board_Tag -> boardTag로 변경했습니다.

3. 삭제 테스트를 하기 위해 어플리케이션과 테스트에 초기 데이터를 추가하였습니다.