### PR TITLE
[Feat] 메인페이지 레이아웃/스타일 적용

### DIFF
--- a/front/src/component/common/Post.jsx
+++ b/front/src/component/common/Post.jsx
@@ -1,0 +1,189 @@
+import styled from 'styled-components';
+import uuid from 'react-uuid';
+import { GoHeart } from 'react-icons/go';
+
+const PostWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  flex: none;
+  flex-basis: 25%;
+  padding: 4rem 1.2rem 0;
+
+  .post__container {
+    display: flex;
+    flex-direction: column;
+    box-shadow: 0 0 6px rgba(0, 0, 0, 0.16);
+    border-radius: var(--radius-10);
+    overflow: hidden;
+    background: #fff;
+
+    .post__img {
+      flex: auto;
+      overflow: hidden;
+      cursor: pointer;
+
+      .post__q {
+        width: 100%;
+        height: 100%;
+        transition: all 300ms linear;
+        &:hover {
+          transform: scale(1.03);
+        }
+      }
+    }
+
+    .post__card {
+      display: flex;
+      flex-direction: column;
+      padding: 1rem 1.5rem;
+
+      /* 말줄임 속성 */
+      .post__title,
+      .post__writer {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        display: -webkit-box;
+        -webkit-line-clamp: 1;
+        -webkit-box-orient: vertical;
+        word-break: break-all;
+      }
+
+      .post__tl {
+        display: flex;
+        align-items: center;
+        padding: 5px 0;
+
+        .post__title {
+          flex-grow: 2;
+          text-align: left;
+          font-weight: bold;
+          font-size: 1.6rem;
+          cursor: pointer;
+        }
+
+        .post__heart {
+          display: flex;
+          align-items: center;
+          padding-left: 5px;
+
+          .heart__icon {
+            width: 2rem;
+            height: 2rem;
+            fill: var(--button-theme);
+          }
+
+          .heart__count {
+            font-size: 1.4rem;
+            color: var(--button-theme);
+            padding-left: 2px;
+            margin-top: -1px;
+          }
+        }
+      }
+
+      .post__tw {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        flex-wrap: wrap;
+        margin: 1.2rem 0 5px;
+
+        .post__tags {
+          display: flex;
+          justify-content: flex-start;
+          align-items: center;
+          flex-wrap: wrap;
+          padding: 5px 0;
+          overflow: hidden;
+          white-space: nowrap;
+          text-overflow: ellipsis;
+
+          .post__tag {
+            padding-right: 5px;
+            text-align: left;
+            color: var(--font-tag-color);
+            font-size: 1.2rem;
+            cursor: pointer;
+          }
+        }
+        .post__info {
+          display: flex;
+          align-items: center;
+          padding: 5px 0;
+          cursor: pointer;
+
+          .post__avatar {
+            display: block;
+            width: 2rem;
+            height: 2rem;
+            margin-right: 5px;
+            border-radius: 50%;
+            overflow: hidden;
+          }
+
+          .post__writer {
+            font-size: 1.2rem;
+          }
+        }
+      }
+    }
+  }
+`;
+// { image, title, like, tag, user }
+function Post() {
+  return (
+    <PostWrapper className="post">
+      <div className="post__container">
+        <div className="post__img">
+          {/* post Image */}
+          <img
+            className="post__q"
+            src="https://source.unsplash.com/random/425x300"
+            alt="게시글"
+          />
+        </div>
+        <div className="post__card">
+          <div className="post__tl">
+            {/* title && like */}
+            <p className="post__title">
+              안녕 나는 제목이야 안녕 나는 제목이야 안녕 나는 제목이야
+            </p>
+            <p className="post__heart">
+              <GoHeart className="heart__icon" />
+              <span className="heart__count">5</span>
+            </p>
+          </div>
+          <div className="post__tw">
+            {/* tag && user */}
+            <ul className="post__tags">
+              {/* tag.map(el => {
+            <li key={uuid()} className="post__tag">el</li>
+          }) */}
+              <li key={uuid()} className="post__tag">
+                #태그는6글자
+              </li>
+              <li key={uuid()} className="post__tag">
+                #이하로만가능
+              </li>
+              <li key={uuid()} className="post__tag">
+                #하도록해야지
+              </li>
+            </ul>
+            <div className="post__info">
+              <span className="post__avatar">
+                <img
+                  className="post__user"
+                  src="https://source.unsplash.com/random/20x20/"
+                  alt="유저"
+                />
+              </span>
+              <p className="post__writer">안녕나는유저야</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </PostWrapper>
+  );
+}
+
+export default Post;

--- a/front/src/component/common/Post.jsx
+++ b/front/src/component/common/Post.jsx
@@ -17,12 +17,12 @@ const PostWrapper = styled.div`
     overflow: hidden;
     background: #fff;
 
-    .post__img {
+    .post__thumb {
       flex: auto;
       overflow: hidden;
       cursor: pointer;
 
-      .post__q {
+      .post__img {
         width: 100%;
         height: 100%;
         transition: all 300ms linear;
@@ -134,10 +134,10 @@ function Post() {
   return (
     <PostWrapper className="post">
       <div className="post__container">
-        <div className="post__img">
+        <div className="post__thumb">
           {/* post Image */}
           <img
-            className="post__q"
+            className="post__img"
             src="https://source.unsplash.com/random/425x300"
             alt="게시글"
           />

--- a/front/src/component/main/MainContents.jsx
+++ b/front/src/component/main/MainContents.jsx
@@ -7,10 +7,32 @@ const MainContainer = styled.section`
   padding: 0 calc(10rem - 1.2rem);
   position: relative;
 
+  @media screen and (max-width: 549px) {
+    padding: 0;
+  }
+
   .main__container {
     max-width: 172rem;
     display: flex;
     flex-wrap: wrap;
+
+    @media screen and (max-width: 1440px) {
+      .post {
+        flex-basis: 33.3%;
+      }
+    }
+
+    @media screen and (max-width: 1024px) {
+      .post {
+        flex-basis: 50%;
+      }
+    }
+
+    @media screen and (max-width: 549px) {
+      .post {
+        flex-basis: 100%;
+      }
+    }
   }
 `;
 

--- a/front/src/component/main/MainContents.jsx
+++ b/front/src/component/main/MainContents.jsx
@@ -1,0 +1,35 @@
+import styled from 'styled-components';
+import Post from '../common/Post';
+import MainSort from './MainSort';
+
+const MainContainer = styled.section`
+  width: 100%;
+  padding: 0 calc(10rem - 1.2rem);
+  position: relative;
+
+  .main__container {
+    max-width: 172rem;
+    display: flex;
+    flex-wrap: wrap;
+  }
+`;
+
+function MainContents() {
+  return (
+    <MainContainer>
+      <MainSort />
+      <div className="main__container">
+        <Post />
+        <Post />
+        <Post />
+        <Post />
+        <Post />
+        <Post />
+        <Post />
+        <Post />
+      </div>
+    </MainContainer>
+  );
+}
+
+export default MainContents;

--- a/front/src/component/main/MainSort.jsx
+++ b/front/src/component/main/MainSort.jsx
@@ -1,0 +1,59 @@
+import styled from 'styled-components';
+
+const MainSortBar = styled.div`
+  position: absolute;
+  top: 1.2rem;
+  right: 10rem;
+
+  @media screen and (max-width: 549px) {
+    display: none;
+  }
+
+  .main__sortbar {
+    display: flex;
+
+    > li {
+      margin-right: 1.5rem;
+      position: relative;
+
+      &::after {
+        position: absolute;
+        top: 1px;
+        left: 4.2rem;
+        content: '';
+        width: 1px;
+        height: 1.3rem;
+        background: var(--font-base-black);
+      }
+      &:last-child::after {
+        display: none;
+      }
+
+      > button {
+        background: none;
+        border: none;
+        cursor: pointer;
+      }
+    }
+  }
+`;
+
+function MainSort() {
+  return (
+    <MainSortBar>
+      <ul className="main__sortbar">
+        <li>
+          <button>최신글</button>
+        </li>
+        <li>
+          <button>추천수</button>
+        </li>
+        <li>
+          <button>조회수</button>
+        </li>
+      </ul>
+    </MainSortBar>
+  );
+}
+
+export default MainSort;

--- a/front/src/component/main/MainTheme.jsx
+++ b/front/src/component/main/MainTheme.jsx
@@ -1,0 +1,68 @@
+import styled from 'styled-components';
+import { BiRestaurant, BiHotel, BiMap } from 'react-icons/bi';
+
+const MainThemeBar = styled.div`
+  width: 100%;
+  box-shadow: 0 0 6px rgba(0, 0, 0, 0.16);
+
+  .theme__lists {
+    display: flex;
+    justify-content: center;
+    > li {
+      margin: 0 2rem;
+      color: var(--font-base-grey);
+
+      > button {
+        height: 5rem;
+        background: none;
+        border: none;
+        display: flex;
+        align-items: center;
+        cursor: pointer;
+        > svg {
+          width: 2rem;
+          height: 2rem;
+        }
+
+        > span {
+          font-size: 1.6rem;
+          padding-left: 5px;
+        }
+      }
+
+      &.active {
+        color: var(--font-base-black);
+        border-bottom: 2px solid var(--font-base-black);
+      }
+    }
+  }
+`;
+
+function MainTheme() {
+  return (
+    <MainThemeBar>
+      <ul className="theme__lists">
+        <li className="theme__restarant active">
+          <button>
+            <BiRestaurant />
+            <span>맛집</span>
+          </button>
+        </li>
+        <li className="theme__hotel">
+          <button>
+            <BiHotel />
+            <span>숙소 </span>
+          </button>
+        </li>
+        <li className="theme__trip">
+          <button>
+            <BiMap />
+            <span>여행지</span>
+          </button>
+        </li>
+      </ul>
+    </MainThemeBar>
+  );
+}
+
+export default MainTheme;

--- a/front/src/pages/MainPage.jsx
+++ b/front/src/pages/MainPage.jsx
@@ -1,0 +1,18 @@
+import styled from 'styled-components';
+import MainContents from '../component/main/MainContents';
+import MainTheme from '../component/main/MainTheme';
+
+const Main = styled.main`
+  padding: 8rem 0 4rem;
+`;
+
+function MainPage() {
+  return (
+    <Main>
+      <MainTheme />
+      <MainContents />
+    </Main>
+  );
+}
+
+export default MainPage;


### PR DESCRIPTION
- Post 공통 컴포넌트화
`경호님이 작업하신 Post 컴포넌트 일부 수정하여 공통 컴포넌트화 했습니다.`
- 메인페이지 구성 컴포넌트 레이아웃, 스타일 적용
`Sort 컴포넌트는 테마와 같은 라인에서는 어떤 방법을 적용해도 겹쳐서 그냥 아래로 뺐습니다.`
- 해상도가 줄어들때마다 컨텐츠도 줄어들도록 반응형 형태로 적용
- 아래 해상도 기준 화면에 보이는 `Post` 개수가 달라지도록 미디어쿼리 적용
`1920px~1441px : 4개 / 1440px~1025px : 3개 / 1024px~550px: : 2개 / 549px~ : 1개`
