### PR TITLE
[Feat] 게시글 수정 API 구현 및 테스트

### DIFF
--- a/back/src/main/java/travelRepo/domain/board/controller/BoardController.java
+++ b/back/src/main/java/travelRepo/domain/board/controller/BoardController.java
@@ -40,9 +40,13 @@ public class BoardController {
     }
 
     @PostMapping("/{boardId}")
-    public ResponseEntity<IdDto> boardModify(@ModelAttribute BoardModifyReq boardModifyReq,
+    public ResponseEntity<IdDto> boardModify(@LoginAccountId Long loginAccountId,
+                                             @Valid @ModelAttribute BoardModifyReq boardModifyReq,
                                              @PathVariable Long boardId) {
-        return new ResponseEntity(new IdDto(1L), HttpStatus.OK);
+
+        IdDto response = boardService.modifyBoard(loginAccountId, boardModifyReq, boardId);
+
+        return new ResponseEntity(response, HttpStatus.OK);
     }
 
     @DeleteMapping("/{boardId}")

--- a/back/src/main/java/travelRepo/domain/board/dto/BoardAddReq.java
+++ b/back/src/main/java/travelRepo/domain/board/dto/BoardAddReq.java
@@ -13,9 +13,11 @@ import java.util.List;
 @Data
 public class BoardAddReq {
 
+    @NotNull
     @Length(min = 5, max = 40)
     private String title;
 
+    @NotNull
     @Length(min = 5)
     private String content;
 

--- a/back/src/main/java/travelRepo/domain/board/dto/BoardModifyReq.java
+++ b/back/src/main/java/travelRepo/domain/board/dto/BoardModifyReq.java
@@ -1,7 +1,9 @@
 package travelRepo.domain.board.dto;
 
 import lombok.Data;
+import org.hibernate.validator.constraints.Length;
 import org.springframework.web.multipart.MultipartFile;
+import travelRepo.domain.board.entity.Board;
 import travelRepo.domain.board.entity.Category;
 
 import java.util.List;
@@ -9,8 +11,10 @@ import java.util.List;
 @Data
 public class BoardModifyReq {
 
+    @Length(min = 5, max = 40)
     private String title;
 
+    @Length(min = 5)
     private String content;
 
     private String location;
@@ -21,4 +25,15 @@ public class BoardModifyReq {
 
     private List<MultipartFile> images;
 
+    public Board toBoard() {
+
+        Board board = Board.builder()
+                .title(title)
+                .content(content)
+                .location(location)
+                .category(category)
+                .build();
+
+        return board;
+    }
 }

--- a/back/src/main/java/travelRepo/domain/board/entity/Board.java
+++ b/back/src/main/java/travelRepo/domain/board/entity/Board.java
@@ -10,6 +10,8 @@ import travelRepo.global.auditing.BaseTime;
 import javax.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+
 
 @Entity
 @Getter
@@ -65,5 +67,12 @@ public class Board extends BaseTime {
         if (boardPhoto.getBoard() == null) {
             boardPhoto.addBoard(this);
         }
+    }
+
+    public void modify(Board board) {
+        Optional.ofNullable(board.getTitle()).ifPresent(title -> this.title = title);
+        Optional.ofNullable(board.getContent()).ifPresent(content -> this.content = content);
+        Optional.ofNullable(board.getLocation()).ifPresent(location -> this.location = location);
+        Optional.ofNullable(board.getCategory()).ifPresent(category -> this.category = category);
     }
 }

--- a/back/src/main/java/travelRepo/domain/board/entity/Board.java
+++ b/back/src/main/java/travelRepo/domain/board/entity/Board.java
@@ -8,7 +8,6 @@ import travelRepo.domain.account.entity.Account;
 import travelRepo.global.auditing.BaseTime;
 
 import javax.persistence.*;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -43,10 +42,10 @@ public class Board extends BaseTime {
     private Category category;
 
     @OneToMany(mappedBy = "board", cascade = CascadeType.PERSIST)
-    private final List<BoardTag> boardTags = new ArrayList<>();
+    private List<BoardTag> boardTags;
 
     @OneToMany(mappedBy = "board", cascade = CascadeType.PERSIST)
-    private final List<BoardPhoto> boardPhotos = new ArrayList<>();
+    private List<BoardPhoto> boardPhotos;
 
     public void addAccount(Account account) {
         this.account = account;
@@ -55,16 +54,16 @@ public class Board extends BaseTime {
         }
     }
 
-    public void addBoardTag(BoardTag boardTag) {
-        this.boardTags.add(boardTag);
-        if (boardTag.getBoard() == null) {
+    public void addBoardTags(List<BoardTag> boardTags) {
+        this.boardTags = boardTags;
+        for (BoardTag boardTag : boardTags) {
             boardTag.addBoard(this);
         }
     }
 
-    public void addBoardPhoto(BoardPhoto boardPhoto) {
-        this.boardPhotos.add(boardPhoto);
-        if (boardPhoto.getBoard() == null) {
+    public void addBoardPhotos(List<BoardPhoto> boardPhotos) {
+        this.boardPhotos = boardPhotos;
+        for (BoardPhoto boardPhoto : boardPhotos) {
             boardPhoto.addBoard(this);
         }
     }

--- a/back/src/main/java/travelRepo/domain/board/entity/BoardPhoto.java
+++ b/back/src/main/java/travelRepo/domain/board/entity/BoardPhoto.java
@@ -27,8 +27,5 @@ public class BoardPhoto {
 
     public void addBoard(Board board) {
         this.board = board;
-        if (!board.getBoardPhotos().contains(this)) {
-            board.addBoardPhoto(this);
-        }
     }
 }

--- a/back/src/main/java/travelRepo/domain/board/entity/BoardTag.java
+++ b/back/src/main/java/travelRepo/domain/board/entity/BoardTag.java
@@ -29,8 +29,5 @@ public class BoardTag {
 
     public void addBoard(Board board) {
         this.board = board;
-        if (!board.getBoardTags().contains(this)) {
-            board.addBoardTag(this);
-        }
     }
 }

--- a/back/src/main/java/travelRepo/domain/board/repository/BoardPhotoRepository.java
+++ b/back/src/main/java/travelRepo/domain/board/repository/BoardPhotoRepository.java
@@ -12,4 +12,8 @@ public interface BoardPhotoRepository extends JpaRepository<BoardPhoto, Long> {
     @Query("delete from BoardPhoto boardPhoto " +
             "where boardPhoto.board in (select board from Board board where board.account.id = :accountId)")
     void deleteByAccountId(@Param("accountId") Long accountId);
+
+    @Modifying(flushAutomatically = true)
+    @Query("delete from BoardPhoto boardPhoto where boardPhoto.board.id = :boardId")
+    void deleteByBoardId(@Param("boardId") Long boardId);
 }

--- a/back/src/main/java/travelRepo/domain/board/repository/BoardRepository.java
+++ b/back/src/main/java/travelRepo/domain/board/repository/BoardRepository.java
@@ -15,7 +15,7 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
     @Query("delete from Board board where board.account.id = :accountId")
     void deleteByAccountId(@Param("accountId") Long accountId);
 
-    @Override
-    @EntityGraph(attributePaths = {"boardTags"})
-    Optional<Board> findById(Long boardId);
+    @EntityGraph(attributePaths = {"boardTags", "account"})
+    @Query("select b from Board b where b.id = :boardId")
+    Optional<Board> findByIdWithBoardTagsAndAccount(@Param("boardId") Long boardId);
 }

--- a/back/src/main/java/travelRepo/domain/board/repository/BoardRepository.java
+++ b/back/src/main/java/travelRepo/domain/board/repository/BoardRepository.java
@@ -1,14 +1,21 @@
 package travelRepo.domain.board.repository;
 
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import travelRepo.domain.board.entity.Board;
 
+import java.util.Optional;
+
 public interface BoardRepository extends JpaRepository<Board, Long> {
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("delete from Board board where board.account.id = :accountId")
     void deleteByAccountId(@Param("accountId") Long accountId);
+
+    @Override
+    @EntityGraph(attributePaths = {"boardTags"})
+    Optional<Board> findById(Long boardId);
 }

--- a/back/src/main/java/travelRepo/domain/board/repository/BoardTagRepository.java
+++ b/back/src/main/java/travelRepo/domain/board/repository/BoardTagRepository.java
@@ -12,4 +12,8 @@ public interface BoardTagRepository extends JpaRepository<BoardTag, Long> {
     @Query("delete from BoardTag boardTag where boardTag.board " +
             "in (select board from Board board where board.account.id = :accountId)")
     void deleteByAccountId(@Param("accountId") Long accountId);
+
+    @Modifying(flushAutomatically = true)
+    @Query("delete from BoardTag boardTag where boardTag.board.id = :boardId")
+    void deleteByBoardId(@Param("boardId") Long boardId);
 }

--- a/back/src/main/java/travelRepo/domain/board/service/BoardService.java
+++ b/back/src/main/java/travelRepo/domain/board/service/BoardService.java
@@ -3,19 +3,26 @@ package travelRepo.domain.board.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 import travelRepo.domain.account.entity.Account;
 import travelRepo.domain.account.repository.AccountRepository;
 import travelRepo.domain.board.dto.BoardAddReq;
+import travelRepo.domain.board.dto.BoardModifyReq;
 import travelRepo.domain.board.entity.Board;
 import travelRepo.domain.board.entity.BoardPhoto;
 import travelRepo.domain.board.entity.BoardTag;
 import travelRepo.domain.board.entity.Tag;
+import travelRepo.domain.board.repository.BoardPhotoRepository;
 import travelRepo.domain.board.repository.BoardRepository;
+import travelRepo.domain.board.repository.BoardTagRepository;
 import travelRepo.domain.board.repository.TagRepository;
 import travelRepo.global.common.dto.IdDto;
 import travelRepo.global.exception.BusinessLogicException;
 import travelRepo.global.exception.ExceptionCode;
 import travelRepo.global.upload.service.UploadService;
+
+import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -23,6 +30,8 @@ import travelRepo.global.upload.service.UploadService;
 public class BoardService {
 
     private final BoardRepository boardRepository;
+    private final BoardPhotoRepository boardPhotoRepository;
+    private final BoardTagRepository boardTagRepository;
     private final AccountRepository accountRepository;
     private final TagRepository tagRepository;
     private final UploadService uploadService;
@@ -34,16 +43,44 @@ public class BoardService {
                 .orElseThrow(() -> new BusinessLogicException(ExceptionCode.NOT_FOUND_ACCOUNT));
 
         Board board = boardAddReq.toBoard(account);
-        addBoardPhotosToBoard(boardAddReq, board);
-        addBoardTagsToBoard(boardAddReq, board);
+        addBoardPhotosToBoard(boardAddReq.getImages(), board);
+        addBoardTagsToBoard(boardAddReq.getTags(), board);
 
         Board savedBoard = boardRepository.save(board);
 
         return new IdDto(savedBoard.getId());
     }
 
-    private void addBoardTagsToBoard(BoardAddReq boardAddReq, Board board) {
-        boardAddReq.getTags()
+    @Transactional
+    public IdDto modifyBoard(Long loginAccountId, BoardModifyReq boardModifyReq, Long boardId) {
+
+        Board board = boardRepository.findById(boardId)
+                .orElseThrow(() -> new BusinessLogicException(ExceptionCode.NOT_FOUND_BOARD));
+
+        if (!loginAccountId.equals(board.getAccount().getId())) {
+            throw new BusinessLogicException(ExceptionCode.FORBIDDEN);
+        }
+
+        Board modifyBoard = boardModifyReq.toBoard();
+        board.modify(modifyBoard);
+
+        Optional.ofNullable(boardModifyReq.getImages()).ifPresent(images -> {
+            board.getBoardPhotos().clear();
+            boardPhotoRepository.deleteByBoardId(boardId);
+            addBoardPhotosToBoard(images, board);
+        });
+
+        Optional.ofNullable(boardModifyReq.getTags()).ifPresent(tagNames -> {
+            board.getBoardTags().clear();
+            boardTagRepository.deleteByBoardId(boardId);
+            addBoardTagsToBoard(boardModifyReq.getTags(), board);
+        });
+
+        return new IdDto(boardId);
+    }
+
+    private void addBoardTagsToBoard(List<String> tagNames, Board board) {
+        tagNames
                 .forEach(tagName -> {
                     Tag tag = findTag(tagName);
                     BoardTag boardTag = BoardTag.builder()
@@ -53,8 +90,8 @@ public class BoardService {
                 });
     }
 
-    private void addBoardPhotosToBoard(BoardAddReq boardAddReq, Board board) {
-        boardAddReq.getImages()
+    private void addBoardPhotosToBoard(List<MultipartFile> images, Board board) {
+        images
                 .forEach(image -> {
                     BoardPhoto boardPhoto = BoardPhoto.builder()
                             .photo(uploadService.upload(image))

--- a/back/src/main/java/travelRepo/domain/board/service/BoardService.java
+++ b/back/src/main/java/travelRepo/domain/board/service/BoardService.java
@@ -23,6 +23,7 @@ import travelRepo.global.upload.service.UploadService;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -65,13 +66,11 @@ public class BoardService {
         board.modify(modifyBoard);
 
         Optional.ofNullable(boardModifyReq.getImages()).ifPresent(images -> {
-            board.getBoardPhotos().clear();
             boardPhotoRepository.deleteByBoardId(boardId);
             addBoardPhotosToBoard(images, board);
         });
 
         Optional.ofNullable(boardModifyReq.getTags()).ifPresent(tagNames -> {
-            board.getBoardTags().clear();
             boardTagRepository.deleteByBoardId(boardId);
             addBoardTagsToBoard(boardModifyReq.getTags(), board);
         });
@@ -80,24 +79,31 @@ public class BoardService {
     }
 
     private void addBoardTagsToBoard(List<String> tagNames, Board board) {
-        tagNames
-                .forEach(tagName -> {
+
+        List<BoardTag> boardTags = tagNames.stream()
+                .map((tagName -> {
                     Tag tag = findTag(tagName);
                     BoardTag boardTag = BoardTag.builder()
                             .tag(tag)
                             .build();
-                    board.addBoardTag(boardTag);
-                });
+                    return boardTag;
+                })).collect(Collectors.toList());
+
+        board.addBoardTags(boardTags);
     }
 
     private void addBoardPhotosToBoard(List<MultipartFile> images, Board board) {
-        images
-                .forEach(image -> {
+
+        List<BoardPhoto> boardPhotos = images.stream()
+                .map(image -> {
                     BoardPhoto boardPhoto = BoardPhoto.builder()
                             .photo(uploadService.upload(image))
                             .build();
-                    board.addBoardPhoto(boardPhoto);
-                });
+                    return boardPhoto;
+                })
+                .collect(Collectors.toList());
+
+        board.addBoardPhotos(boardPhotos);
     }
 
     @Transactional

--- a/back/src/main/java/travelRepo/global/exception/ExceptionCode.java
+++ b/back/src/main/java/travelRepo/global/exception/ExceptionCode.java
@@ -6,10 +6,10 @@ import lombok.Getter;
 public enum ExceptionCode {
 
     NOT_FOUND_ACCOUNT(400, "Account를 찾을 수 없습니다."),
-    NOT_FOUND_BOARD(400, "게시글을 찾을 수 없습니다."),
     DUPLICATION_EMAIL(400, "동일한 Email의 Account가 존재합니다."),
     IlLEGAL_PARAMETER(400, "잘못된 Parameter입니다."),
     FORBIDDEN(403, "잘못된 접근입니다."),
+    NOT_FOUND_BOARD(404, "게시글을 찾을 수 없습니다."),
     UPLOAD_FAILED(500, "이미지를 업로드하는데 실패했습니다.");
 
     private int status;

--- a/back/src/main/java/travelRepo/global/exception/ExceptionCode.java
+++ b/back/src/main/java/travelRepo/global/exception/ExceptionCode.java
@@ -6,8 +6,10 @@ import lombok.Getter;
 public enum ExceptionCode {
 
     NOT_FOUND_ACCOUNT(400, "Account를 찾을 수 없습니다."),
+    NOT_FOUND_BOARD(400, "게시글을 찾을 수 없습니다."),
     DUPLICATION_EMAIL(400, "동일한 Email의 Account가 존재합니다."),
     IlLEGAL_PARAMETER(400, "잘못된 Parameter입니다."),
+    FORBIDDEN(403, "잘못된 접근입니다."),
     UPLOAD_FAILED(500, "이미지를 업로드하는데 실패했습니다.");
 
     private int status;

--- a/back/src/test/java/travelRepo/domain/board/controller/BoardControllerTest.java
+++ b/back/src/test/java/travelRepo/domain/board/controller/BoardControllerTest.java
@@ -282,6 +282,34 @@ class BoardControllerTest {
     }
 
     @Test
+    @DisplayName("게시글 수정_존재하지 않는 게시글")
+    public void boardModify_NOT_FOUND() throws Exception {
+
+        //given
+        Account account = accountRepository.findById(10001L).get();
+        String jwt = "Bearer " + jwtProcessor.createAuthJwtToken(new UserAccount(account));
+
+        Long boardId = 12004L;
+
+        String title = "modified mock board title";
+
+        //when
+        ResultActions actions = mockMvc.perform(
+                multipart("/boards/{boardId}", boardId)
+                        .param("title", title)
+                        .header("Authorization", jwt)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .contentType(MediaType.MULTIPART_FORM_DATA)
+        );
+
+        //then
+        actions
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.exception").value(BusinessLogicException.class.getSimpleName()))
+                .andExpect(jsonPath("$.message").value("게시글을 찾을 수 없습니다."));
+    }
+
+    @Test
     @DisplayName("게시글 수정_잘못된 접근")
     public void boardModify_Forbidden() throws Exception {
 


### PR DESCRIPTION
1. 게시글을 수정하는 API를 구현했습니다.
 - 로그인한 계정과 수정하려는 게시글을 등록한 계정이 다른 경우 에러가 발생합니다.
 - 태그/이미지의 경우 수정될 데이터가 존재하면 기존의 데이터를 전부 지우고 새롭게 등록하는 방식으로 수정됩니다.

2. 게시글 수정 API 테스트 코드를 작성했습니다.