### PR TITLE
[Feat] 게시물 단일 조회 API 구현 및 테스트

### DIFF
--- a/back/src/main/java/travelRepo/domain/account/dto/AccountSummaryRes.java
+++ b/back/src/main/java/travelRepo/domain/account/dto/AccountSummaryRes.java
@@ -1,6 +1,7 @@
 package travelRepo.domain.account.dto;
 
 import lombok.Data;
+import travelRepo.domain.account.entity.Account;
 
 @Data
 public class AccountSummaryRes {
@@ -10,4 +11,14 @@ public class AccountSummaryRes {
     private String profile;
 
     private String nickname;
+
+    static public AccountSummaryRes of (Account account) {
+
+        AccountSummaryRes accountSummaryRes = new AccountSummaryRes();
+        accountSummaryRes.setAccountId(account.getId());
+        accountSummaryRes.setProfile(account.getProfile());
+        accountSummaryRes.setNickname(account.getNickname());
+
+        return accountSummaryRes;
+    }
 }

--- a/back/src/main/java/travelRepo/domain/board/controller/BoardController.java
+++ b/back/src/main/java/travelRepo/domain/board/controller/BoardController.java
@@ -56,30 +56,7 @@ public class BoardController {
     @GetMapping("/{boardId}")
     public ResponseEntity<BoardDetailsRes> boardDetails(@PathVariable Long boardId) {
 
-        AccountSummaryRes account = new AccountSummaryRes();
-        account.setAccountId(1L);
-        account.setProfile("https://main-image-repo.s3.ap-northeast-2.amazonaws.com/%EC%83%88+%ED%8F%B4%EB%8D%94/1.png");
-        account.setNickname("mockAccount");
-
-        BoardDetailsRes response = new BoardDetailsRes();
-        response.setMyBoard(false);
-        response.setBoardId(boardId);
-        response.setTitle("mock board title");
-        response.setContent("mock board content");
-        response.setLocation("mock board location");
-        response.setCategory(Category.SPOT);
-        response.setLikeCount(16);
-        response.setViews(256);
-        response.setTags(
-                List.of("mock tag1", "mock tag2", "mock tag3")
-        );
-        response.setPhotos(
-                List.of("https://main-image-repo.s3.ap-northeast-2.amazonaws.com/%EC%83%88+%ED%8F%B4%EB%8D%94/1.png",
-                        "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/%EC%83%88+%ED%8F%B4%EB%8D%94/2.png",
-                        "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/%EC%83%88+%ED%8F%B4%EB%8D%94/3.png")
-        );
-        response.setCreatedAt(LocalDateTime.now());
-        response.setAccount(account);
+        BoardDetailsRes response = boardService.findBoard(boardId);
 
         return new ResponseEntity(response, HttpStatus.OK);
     }

--- a/back/src/main/java/travelRepo/domain/board/dto/BoardDetailsRes.java
+++ b/back/src/main/java/travelRepo/domain/board/dto/BoardDetailsRes.java
@@ -2,15 +2,15 @@ package travelRepo.domain.board.dto;
 
 import lombok.Data;
 import travelRepo.domain.account.dto.AccountSummaryRes;
+import travelRepo.domain.board.entity.Board;
 import travelRepo.domain.board.entity.Category;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Data
 public class BoardDetailsRes {
-
-    private boolean myBoard;
 
     private Long boardId;
 
@@ -33,4 +33,30 @@ public class BoardDetailsRes {
     private LocalDateTime createdAt;
 
     private AccountSummaryRes account;
+
+    static public BoardDetailsRes of(Board board) {
+
+        BoardDetailsRes boardDetailsRes = new BoardDetailsRes();
+        boardDetailsRes.setBoardId(board.getId());
+        boardDetailsRes.setTitle(board.getTitle());
+        boardDetailsRes.setContent(board.getContent());
+        boardDetailsRes.setLocation(board.getLocation());
+        boardDetailsRes.setCategory(board.getCategory());
+        boardDetailsRes.setLikeCount(board.getLikeCount());
+        boardDetailsRes.setViews(board.getViews());
+        boardDetailsRes.setTags(
+                board.getBoardTags().stream()
+                        .map(boardTag -> boardTag.getTag().getName())
+                        .collect(Collectors.toList())
+        );
+        boardDetailsRes.setPhotos(
+                board.getBoardPhotos().stream()
+                        .map(boardPhoto -> boardPhoto.getPhoto())
+                        .collect(Collectors.toList())
+        );
+        boardDetailsRes.setCreatedAt(board.getCreatedAt());
+        boardDetailsRes.setAccount(AccountSummaryRes.of(board.getAccount()));
+
+        return boardDetailsRes;
+    }
 }

--- a/back/src/main/java/travelRepo/domain/board/entity/Board.java
+++ b/back/src/main/java/travelRepo/domain/board/entity/Board.java
@@ -68,6 +68,10 @@ public class Board extends BaseTime {
         }
     }
 
+    public void increaseViews() {
+        this.views++;
+    }
+
     public void modify(Board board) {
         Optional.ofNullable(board.getTitle()).ifPresent(title -> this.title = title);
         Optional.ofNullable(board.getContent()).ifPresent(content -> this.content = content);

--- a/back/src/main/java/travelRepo/domain/board/service/BoardService.java
+++ b/back/src/main/java/travelRepo/domain/board/service/BoardService.java
@@ -7,6 +7,7 @@ import org.springframework.web.multipart.MultipartFile;
 import travelRepo.domain.account.entity.Account;
 import travelRepo.domain.account.repository.AccountRepository;
 import travelRepo.domain.board.dto.BoardAddReq;
+import travelRepo.domain.board.dto.BoardDetailsRes;
 import travelRepo.domain.board.dto.BoardModifyReq;
 import travelRepo.domain.board.entity.Board;
 import travelRepo.domain.board.entity.BoardPhoto;
@@ -76,6 +77,17 @@ public class BoardService {
         });
 
         return new IdDto(boardId);
+    }
+
+    @Transactional
+    public BoardDetailsRes findBoard(Long boardId) {
+
+        Board board = boardRepository.findByIdWithBoardTagsAndAccount(boardId)
+                .orElseThrow(() -> new BusinessLogicException(ExceptionCode.NOT_FOUND_BOARD));
+
+        board.increaseViews();
+
+        return BoardDetailsRes.of(board);
     }
 
     private void addBoardTagsToBoard(List<String> tagNames, Board board) {

--- a/back/src/main/resources/static/docs/index.html
+++ b/back/src/main/resources/static/docs/index.html
@@ -521,7 +521,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <pre class="prettyprint highlight nowrap"><code data-lang="http">POST /login HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Accept: application/json
-Content-Length: 59
+Content-Length: 62
 Host: localhost:8080
 
 {
@@ -564,7 +564,7 @@ Host: localhost:8080
 Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njg0NzE2ODEsImV4cCI6MTY2ODQ3NTI4MX0.6jnbT6qiUEbcXbayKL891cYB6-Q3y9ySf7-U0nzzykw
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njg1NzcwNjgsImV4cCI6MTY2ODU4MDY2OH0.HXgV5IqCjcEel3TuK5OPfAKMsrjx2XmphVxOE0zTBqs
 X-Content-Type-Options: nosniff
 X-XSS-Protection: 1; mode=block
 Cache-Control: no-cache, no-store, max-age=0, must-revalidate
@@ -704,7 +704,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 14
+Content-Length: 16
 
 {
   "id" : 1
@@ -741,7 +741,7 @@ Content-Length: 14
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/accounts/modify' -i -X POST \
     -H 'Content-Type: multipart/form-data;charset=UTF-8' \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njg0NzE2ODEsImV4cCI6MTY2ODQ3NTI4MX0.6jnbT6qiUEbcXbayKL891cYB6-Q3y9ySf7-U0nzzykw' \
+    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njg1NzcwNjgsImV4cCI6MTY2ODU4MDY2OH0.HXgV5IqCjcEel3TuK5OPfAKMsrjx2XmphVxOE0zTBqs' \
     -F 'profile=@profile.jpeg;type=image/jpeg' \
     -F 'password=123456789' \
     -F 'nickname=modifyTestNickname' \
@@ -753,7 +753,7 @@ Content-Length: 14
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">POST /accounts/modify HTTP/1.1
 Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njg0NzE2ODEsImV4cCI6MTY2ODQ3NTI4MX0.6jnbT6qiUEbcXbayKL891cYB6-Q3y9ySf7-U0nzzykw
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njg1NzcwNjgsImV4cCI6MTY2ODU4MDY2OH0.HXgV5IqCjcEel3TuK5OPfAKMsrjx2XmphVxOE0zTBqs
 Host: localhost:8080
 
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
@@ -866,7 +866,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 18
+Content-Length: 20
 
 {
   "id" : 10001
@@ -902,14 +902,14 @@ Content-Length: 18
 <div class="title">curl-request</div>
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/accounts' -i -X DELETE \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njg0NzE2ODAsImV4cCI6MTY2ODQ3NTI4MH0.J6oni4bTCRiC-RiWI89kVzekb3raRrQv-xzM8KYoXio'</code></pre>
+    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njg1NzcwNjYsImV4cCI6MTY2ODU4MDY2Nn0.JubPWFt9gwfmmwj2ItTcx0D5dFxotEP0GeGSMJMf2DQ'</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">http-request</div>
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">DELETE /accounts HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njg0NzE2ODAsImV4cCI6MTY2ODQ3NTI4MH0.J6oni4bTCRiC-RiWI89kVzekb3raRrQv-xzM8KYoXio
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njg1NzcwNjYsImV4cCI6MTY2ODU4MDY2Nn0.JubPWFt9gwfmmwj2ItTcx0D5dFxotEP0GeGSMJMf2DQ
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -1002,7 +1002,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 257
+Content-Length: 265
 
 {
   "id" : 10001,
@@ -1074,14 +1074,14 @@ Content-Length: 257
 <div class="title">curl-request</div>
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/accounts/login' -i -X GET \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njg0NzE2ODEsImV4cCI6MTY2ODQ3NTI4MX0.6jnbT6qiUEbcXbayKL891cYB6-Q3y9ySf7-U0nzzykw'</code></pre>
+    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njg1NzcwNjgsImV4cCI6MTY2ODU4MDY2OH0.HXgV5IqCjcEel3TuK5OPfAKMsrjx2XmphVxOE0zTBqs'</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">http-request</div>
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">GET /accounts/login HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njg0NzE2ODEsImV4cCI6MTY2ODQ3NTI4MX0.6jnbT6qiUEbcXbayKL891cYB6-Q3y9ySf7-U0nzzykw
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njg1NzcwNjgsImV4cCI6MTY2ODU4MDY2OH0.HXgV5IqCjcEel3TuK5OPfAKMsrjx2XmphVxOE0zTBqs
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -1121,7 +1121,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 257
+Content-Length: 265
 
 {
   "id" : 10001,
@@ -1192,15 +1192,15 @@ Content-Length: 257
 <div class="listingblock">
 <div class="title">curl-request</div>
 <div class="content">
-<pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/accounts/follow/10002?page=2&amp;size=5&amp;sort=createdAt%2Cdesc&amp;status=following' -i -X GET \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njg0NzE2ODEsImV4cCI6MTY2ODQ3NTI4MX0.6jnbT6qiUEbcXbayKL891cYB6-Q3y9ySf7-U0nzzykw'</code></pre>
+<pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/accounts/follow/10001?page=1&amp;size=5&amp;sort=createdAt%2Cdesc&amp;status=following' -i -X GET \
+    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njg1NzcwNjcsImV4cCI6MTY2ODU4MDY2N30.fszTcGAzdtpWz7ZE1OMd7HQe9HMUMhoXBP2Vz1KBEq0'</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">http-request</div>
 <div class="content">
-<pre class="prettyprint highlight nowrap"><code data-lang="http">GET /accounts/follow/10002?page=2&amp;size=5&amp;sort=createdAt%2Cdesc&amp;status=following HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njg0NzE2ODEsImV4cCI6MTY2ODQ3NTI4MX0.6jnbT6qiUEbcXbayKL891cYB6-Q3y9ySf7-U0nzzykw
+<pre class="prettyprint highlight nowrap"><code data-lang="http">GET /accounts/follow/10001?page=1&amp;size=5&amp;sort=createdAt%2Cdesc&amp;status=following HTTP/1.1
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njg1NzcwNjcsImV4cCI6MTY2ODU4MDY2N30.fszTcGAzdtpWz7ZE1OMd7HQe9HMUMhoXBP2Vz1KBEq0
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -1275,7 +1275,7 @@ Host: localhost:8080</code></pre>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>sort</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">정렬 조건(default = asc)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">정렬 조건(default = follow 생성일자)</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>false</code></p></td>
 </tr>
 <tr>
@@ -1299,148 +1299,38 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 3098
+Content-Length: 993
 
 {
   "content" : [ {
-    "id" : 1,
-    "nickname" : "mockNickname1",
-    "profile" : "/mock/path1",
-    "follow" : false,
+    "id" : 10003,
+    "nickname" : "testNickname3",
+    "profile" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
+    "follow" : true,
     "boards" : [ {
-      "id" : 2,
-      "thumbnail" : "/mock/path2",
-      "title" : "mockTitle2"
-    }, {
-      "id" : 3,
-      "thumbnail" : "/mock/path3",
-      "title" : "mockTitle3"
-    }, {
-      "id" : 4,
-      "thumbnail" : "/mock/path4",
-      "title" : "mockTitle4"
-    }, {
-      "id" : 5,
-      "thumbnail" : "/mock/path5",
-      "title" : "mockTitle5"
-    }, {
-      "id" : 6,
-      "thumbnail" : "/mock/path6",
-      "title" : "mockTitle6"
+      "id" : 12003,
+      "thumbnail" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
+      "title" : "testTitle"
     } ]
   }, {
-    "id" : 7,
-    "nickname" : "mockNickname7",
-    "profile" : "/mock/path7",
-    "follow" : false,
+    "id" : 10002,
+    "nickname" : "testNickname2",
+    "profile" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
+    "follow" : true,
     "boards" : [ {
-      "id" : 8,
-      "thumbnail" : "/mock/path8",
-      "title" : "mockTitle8"
-    }, {
-      "id" : 9,
-      "thumbnail" : "/mock/path9",
-      "title" : "mockTitle9"
-    }, {
-      "id" : 10,
-      "thumbnail" : "/mock/path10",
-      "title" : "mockTitle10"
-    }, {
-      "id" : 11,
-      "thumbnail" : "/mock/path11",
-      "title" : "mockTitle11"
-    }, {
-      "id" : 12,
-      "thumbnail" : "/mock/path12",
-      "title" : "mockTitle12"
-    } ]
-  }, {
-    "id" : 13,
-    "nickname" : "mockNickname13",
-    "profile" : "/mock/path13",
-    "follow" : false,
-    "boards" : [ {
-      "id" : 14,
-      "thumbnail" : "/mock/path14",
-      "title" : "mockTitle14"
-    }, {
-      "id" : 15,
-      "thumbnail" : "/mock/path15",
-      "title" : "mockTitle15"
-    }, {
-      "id" : 16,
-      "thumbnail" : "/mock/path16",
-      "title" : "mockTitle16"
-    }, {
-      "id" : 17,
-      "thumbnail" : "/mock/path17",
-      "title" : "mockTitle17"
-    }, {
-      "id" : 18,
-      "thumbnail" : "/mock/path18",
-      "title" : "mockTitle18"
-    } ]
-  }, {
-    "id" : 19,
-    "nickname" : "mockNickname19",
-    "profile" : "/mock/path19",
-    "follow" : false,
-    "boards" : [ {
-      "id" : 20,
-      "thumbnail" : "/mock/path20",
-      "title" : "mockTitle20"
-    }, {
-      "id" : 21,
-      "thumbnail" : "/mock/path21",
-      "title" : "mockTitle21"
-    }, {
-      "id" : 22,
-      "thumbnail" : "/mock/path22",
-      "title" : "mockTitle22"
-    }, {
-      "id" : 23,
-      "thumbnail" : "/mock/path23",
-      "title" : "mockTitle23"
-    }, {
-      "id" : 24,
-      "thumbnail" : "/mock/path24",
-      "title" : "mockTitle24"
-    } ]
-  }, {
-    "id" : 25,
-    "nickname" : "mockNickname25",
-    "profile" : "/mock/path25",
-    "follow" : false,
-    "boards" : [ {
-      "id" : 26,
-      "thumbnail" : "/mock/path26",
-      "title" : "mockTitle26"
-    }, {
-      "id" : 27,
-      "thumbnail" : "/mock/path27",
-      "title" : "mockTitle27"
-    }, {
-      "id" : 28,
-      "thumbnail" : "/mock/path28",
-      "title" : "mockTitle28"
-    }, {
-      "id" : 29,
-      "thumbnail" : "/mock/path29",
-      "title" : "mockTitle29"
-    }, {
-      "id" : 30,
-      "thumbnail" : "/mock/path30",
-      "title" : "mockTitle30"
+      "id" : 12002,
+      "thumbnail" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
+      "title" : "testTitle"
     } ]
   } ],
-  "totalPages" : 6,
-  "totalElements" : 30,
-  "first" : false,
-  "last" : false,
+  "totalPages" : 1,
+  "totalElements" : 2,
+  "first" : true,
+  "last" : true,
   "sorted" : true,
   "size" : 5,
-  "pageNumber" : 3,
-  "numberOfElements" : 5
+  "pageNumber" : 1,
+  "numberOfElements" : 2
 }</code></pre>
 </div>
 </div>
@@ -1532,7 +1422,7 @@ Content-Length: 3098
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>pageNumber</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">페이지 번호(0부터 시작)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">페이지 번호(1부터 시작)</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>numberOfElements</code></p></td>
@@ -1555,18 +1445,18 @@ Content-Length: 3098
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/boards' -i -X POST \
     -H 'Content-Type: multipart/form-data;charset=UTF-8' \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njg0NzE2ODIsImV4cCI6MTY2ODQ3NTI4Mn0.oad5divFnBt6LGs4HRSASbJd2M2zWJjCNxaAR9bsK0Q' \
+    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njg1NzcwNzAsImV4cCI6MTY2ODU4MDY3MH0.lT9u4iUsmtlE5psSgp2G_Tzcc5ZDezMMSid4yVQ4vW0' \
     -H 'Accept: application/json' \
     -F 'images=@image1.png;type=image/png' \
     -F 'images=@image2.png;type=image/png' \
     -F 'images=@image3.png;type=image/png' \
-    -F 'title=mock board title' \
-    -F 'content=mock board content' \
-    -F 'location=mock board location' \
+    -F 'title=board title' \
+    -F 'content=board content' \
+    -F 'location=board location' \
     -F 'category=SPOT' \
-    -F 'tags=mock tag1' \
-    -F 'tags=mock tag2' \
-    -F 'tags=mock tag3'</code></pre>
+    -F 'tags=tag1' \
+    -F 'tags=tag2' \
+    -F 'tags=tag3'</code></pre>
 </div>
 </div>
 <div class="listingblock">
@@ -1574,22 +1464,22 @@ Content-Length: 3098
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">POST /boards HTTP/1.1
 Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njg0NzE2ODIsImV4cCI6MTY2ODQ3NTI4Mn0.oad5divFnBt6LGs4HRSASbJd2M2zWJjCNxaAR9bsK0Q
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njg1NzcwNzAsImV4cCI6MTY2ODU4MDY3MH0.lT9u4iUsmtlE5psSgp2G_Tzcc5ZDezMMSid4yVQ4vW0
 Accept: application/json
 Host: localhost:8080
 
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
 Content-Disposition: form-data; name=title
 
-mock board title
+board title
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
 Content-Disposition: form-data; name=content
 
-mock board content
+board content
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
 Content-Disposition: form-data; name=location
 
-mock board location
+board location
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
 Content-Disposition: form-data; name=category
 
@@ -1597,15 +1487,15 @@ SPOT
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
 Content-Disposition: form-data; name=tags
 
-mock tag1
+tag1
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
 Content-Disposition: form-data; name=tags
 
-mock tag2
+tag2
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
 Content-Disposition: form-data; name=tags
 
-mock tag3
+tag3
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
 Content-Disposition: form-data; name=images; filename=image1.png
 Content-Type: image/png
@@ -1724,10 +1614,10 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 14
+Content-Length: 16
 
 {
-  "id" : 1
+  "id" : 4
 }</code></pre>
 </div>
 </div>
@@ -1759,9 +1649,9 @@ Content-Length: 14
 <div class="listingblock">
 <div class="title">curl-request</div>
 <div class="content">
-<pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/boards/1' -i -X POST \
+<pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/boards/12001' -i -X POST \
     -H 'Content-Type: multipart/form-data;charset=UTF-8' \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njg0NzE2ODIsImV4cCI6MTY2ODQ3NTI4Mn0.oad5divFnBt6LGs4HRSASbJd2M2zWJjCNxaAR9bsK0Q' \
+    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njg1NzcwNzAsImV4cCI6MTY2ODU4MDY3MH0.lT9u4iUsmtlE5psSgp2G_Tzcc5ZDezMMSid4yVQ4vW0' \
     -H 'Accept: application/json' \
     -F 'images=@image1.png;type=image/png' \
     -F 'images=@image4.png;type=image/png' \
@@ -1778,9 +1668,9 @@ Content-Length: 14
 <div class="listingblock">
 <div class="title">http-request</div>
 <div class="content">
-<pre class="prettyprint highlight nowrap"><code data-lang="http">POST /boards/1 HTTP/1.1
+<pre class="prettyprint highlight nowrap"><code data-lang="http">POST /boards/12001 HTTP/1.1
 Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njg0NzE2ODIsImV4cCI6MTY2ODQ3NTI4Mn0.oad5divFnBt6LGs4HRSASbJd2M2zWJjCNxaAR9bsK0Q
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njg1NzcwNzAsImV4cCI6MTY2ODU4MDY3MH0.lT9u4iUsmtlE5psSgp2G_Tzcc5ZDezMMSid4yVQ4vW0
 Accept: application/json
 Host: localhost:8080
 
@@ -1952,10 +1842,10 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 14
+Content-Length: 20
 
 {
-  "id" : 1
+  "id" : 12001
 }</code></pre>
 </div>
 </div>
@@ -1988,14 +1878,14 @@ Content-Length: 14
 <div class="title">curl-request</div>
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/boards/1' -i -X DELETE \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njg0NzE2ODIsImV4cCI6MTY2ODQ3NTI4Mn0.oad5divFnBt6LGs4HRSASbJd2M2zWJjCNxaAR9bsK0Q'</code></pre>
+    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njg1NzcwNzAsImV4cCI6MTY2ODU4MDY3MH0.lT9u4iUsmtlE5psSgp2G_Tzcc5ZDezMMSid4yVQ4vW0'</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">http-request</div>
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">DELETE /boards/1 HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njg0NzE2ODIsImV4cCI6MTY2ODQ3NTI4Mn0.oad5divFnBt6LGs4HRSASbJd2M2zWJjCNxaAR9bsK0Q
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njg1NzcwNzAsImV4cCI6MTY2ODU4MDY3MH0.lT9u4iUsmtlE5psSgp2G_Tzcc5ZDezMMSid4yVQ4vW0
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -2064,14 +1954,14 @@ X-Frame-Options: DENY</code></pre>
 <div class="listingblock">
 <div class="title">curl-request</div>
 <div class="content">
-<pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/boards/1' -i -X GET \
+<pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/boards/12001' -i -X GET \
     -H 'Accept: application/json'</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">http-request</div>
 <div class="content">
-<pre class="prettyprint highlight nowrap"><code data-lang="http">GET /boards/1 HTTP/1.1
+<pre class="prettyprint highlight nowrap"><code data-lang="http">GET /boards/12001 HTTP/1.1
 Accept: application/json
 Host: localhost:8080</code></pre>
 </div>
@@ -2112,24 +2002,23 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 788
+Content-Length: 786
 
 {
-  "myBoard" : false,
-  "boardId" : 1,
-  "title" : "mock board title",
-  "content" : "mock board content",
-  "location" : "mock board location",
-  "category" : "SPOT",
-  "likeCount" : 16,
-  "views" : 256,
-  "tags" : [ "mock tag1", "mock tag2", "mock tag3" ],
-  "photos" : [ "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/%EC%83%88+%ED%8F%B4%EB%8D%94/1.png", "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/%EC%83%88+%ED%8F%B4%EB%8D%94/2.png", "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/%EC%83%88+%ED%8F%B4%EB%8D%94/3.png" ],
-  "createdAt" : "2022-11-15T09:21:22.397119",
+  "boardId" : 12001,
+  "title" : "testTitle",
+  "content" : "testContents",
+  "location" : "test-location",
+  "category" : "RESTAURANT",
+  "likeCount" : 1,
+  "views" : 11,
+  "tags" : [ "testName1", "testName2" ],
+  "photos" : [ "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg", "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg", "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg" ],
+  "createdAt" : "2022-10-14T12:00:01",
   "account" : {
-    "accountId" : 1,
-    "profile" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/%EC%83%88+%ED%8F%B4%EB%8D%94/1.png",
-    "nickname" : "mockAccount"
+    "accountId" : 10001,
+    "profile" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
+    "nickname" : "testNickname1"
   }
 }</code></pre>
 </div>
@@ -2149,11 +2038,6 @@ Content-Length: 788
 </tr>
 </thead>
 <tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>myBoard</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">로그인한 회원이 쓴 글일지 확인</p></td>
-</tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>boardId</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
@@ -2285,7 +2169,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 9016
+Content-Length: 9242
 
 {
   "content" : [ {
@@ -2657,7 +2541,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 2313
+Content-Length: 2374
 
 {
   "content" : [ {
@@ -2824,7 +2708,7 @@ Content-Length: 2313
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/comments' -i -X POST \
     -H 'Content-Type: application/json;charset=UTF-8' \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njg0NzE2ODIsImV4cCI6MTY2ODQ3NTI4Mn0.oad5divFnBt6LGs4HRSASbJd2M2zWJjCNxaAR9bsK0Q' \
+    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njg1NzcwNzEsImV4cCI6MTY2ODU4MDY3MX0.8tPLiVTzvZmvJfXoaiDwxkGNlJM8R5i42m2SfWCs9a8' \
     -d '{
   "boardId" : 1,
   "content" : "mock board content"
@@ -2836,8 +2720,8 @@ Content-Length: 2313
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">POST /comments HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njg0NzE2ODIsImV4cCI6MTY2ODQ3NTI4Mn0.oad5divFnBt6LGs4HRSASbJd2M2zWJjCNxaAR9bsK0Q
-Content-Length: 55
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njg1NzcwNzEsImV4cCI6MTY2ODU4MDY3MX0.8tPLiVTzvZmvJfXoaiDwxkGNlJM8R5i42m2SfWCs9a8
+Content-Length: 58
 Host: localhost:8080
 
 {
@@ -2918,7 +2802,7 @@ X-Frame-Options: DENY</code></pre>
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/comments/1' -i -X PATCH \
     -H 'Content-Type: application/json;charset=UTF-8' \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njg0NzE2ODIsImV4cCI6MTY2ODQ3NTI4Mn0.oad5divFnBt6LGs4HRSASbJd2M2zWJjCNxaAR9bsK0Q' \
+    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njg1NzcwNzEsImV4cCI6MTY2ODU4MDY3MX0.8tPLiVTzvZmvJfXoaiDwxkGNlJM8R5i42m2SfWCs9a8' \
     -d '{
   "content" : "modified mock board content"
 }'</code></pre>
@@ -2929,8 +2813,8 @@ X-Frame-Options: DENY</code></pre>
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">PATCH /comments/1 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njg0NzE2ODIsImV4cCI6MTY2ODQ3NTI4Mn0.oad5divFnBt6LGs4HRSASbJd2M2zWJjCNxaAR9bsK0Q
-Content-Length: 47
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njg1NzcwNzEsImV4cCI6MTY2ODU4MDY3MX0.8tPLiVTzvZmvJfXoaiDwxkGNlJM8R5i42m2SfWCs9a8
+Content-Length: 49
 Host: localhost:8080
 
 {
@@ -3026,14 +2910,14 @@ X-Frame-Options: DENY</code></pre>
 <div class="title">curl-request</div>
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/comments/1' -i -X DELETE \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njg0NzE2ODIsImV4cCI6MTY2ODQ3NTI4Mn0.oad5divFnBt6LGs4HRSASbJd2M2zWJjCNxaAR9bsK0Q'</code></pre>
+    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njg1NzcwNzEsImV4cCI6MTY2ODU4MDY3MX0.8tPLiVTzvZmvJfXoaiDwxkGNlJM8R5i42m2SfWCs9a8'</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">http-request</div>
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">DELETE /comments/1 HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njg0NzE2ODIsImV4cCI6MTY2ODQ3NTI4Mn0.oad5divFnBt6LGs4HRSASbJd2M2zWJjCNxaAR9bsK0Q
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njg1NzcwNzEsImV4cCI6MTY2ODU4MDY3MX0.8tPLiVTzvZmvJfXoaiDwxkGNlJM8R5i42m2SfWCs9a8
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -3150,13 +3034,13 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 1650
+Content-Length: 1707
 
 {
   "content" : [ {
     "commentId" : 1,
     "content" : "mock comment content1",
-    "createdAt" : "2022-11-15T09:21:22.479909",
+    "createdAt" : "2022-11-16T14:37:51.0096458",
     "account" : {
       "accountId" : 1,
       "profile" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/%EC%83%88+%ED%8F%B4%EB%8D%94/1.png",
@@ -3165,7 +3049,7 @@ Content-Length: 1650
   }, {
     "commentId" : 2,
     "content" : "mock comment content2",
-    "createdAt" : "2022-11-15T09:21:22.479925",
+    "createdAt" : "2022-11-16T14:37:51.0096458",
     "account" : {
       "accountId" : 2,
       "profile" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/%EC%83%88+%ED%8F%B4%EB%8D%94/2.png",
@@ -3174,7 +3058,7 @@ Content-Length: 1650
   }, {
     "commentId" : 3,
     "content" : "mock comment content3",
-    "createdAt" : "2022-11-15T09:21:22.47993",
+    "createdAt" : "2022-11-16T14:37:51.0096458",
     "account" : {
       "accountId" : 3,
       "profile" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/%EC%83%88+%ED%8F%B4%EB%8D%94/3.png",
@@ -3183,7 +3067,7 @@ Content-Length: 1650
   }, {
     "commentId" : 4,
     "content" : "mock comment content4",
-    "createdAt" : "2022-11-15T09:21:22.479934",
+    "createdAt" : "2022-11-16T14:37:51.0096458",
     "account" : {
       "accountId" : 4,
       "profile" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/%EC%83%88+%ED%8F%B4%EB%8D%94/4.png",
@@ -3192,7 +3076,7 @@ Content-Length: 1650
   }, {
     "commentId" : 5,
     "content" : "mock comment content5",
-    "createdAt" : "2022-11-15T09:21:22.479938",
+    "createdAt" : "2022-11-16T14:37:51.0096458",
     "account" : {
       "accountId" : 5,
       "profile" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/%EC%83%88+%ED%8F%B4%EB%8D%94/5.png",
@@ -3296,14 +3180,14 @@ Content-Length: 1650
 <div class="title">curl-request</div>
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/follows/2' -i -X POST \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njg0NzE2ODIsImV4cCI6MTY2ODQ3NTI4Mn0.oad5divFnBt6LGs4HRSASbJd2M2zWJjCNxaAR9bsK0Q'</code></pre>
+    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njg1NzcwNzEsImV4cCI6MTY2ODU4MDY3MX0.8tPLiVTzvZmvJfXoaiDwxkGNlJM8R5i42m2SfWCs9a8'</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">http-request</div>
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">POST /follows/2 HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njg0NzE2ODIsImV4cCI6MTY2ODQ3NTI4Mn0.oad5divFnBt6LGs4HRSASbJd2M2zWJjCNxaAR9bsK0Q
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njg1NzcwNzEsImV4cCI6MTY2ODU4MDY3MX0.8tPLiVTzvZmvJfXoaiDwxkGNlJM8R5i42m2SfWCs9a8
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -3365,7 +3249,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 26
+Content-Length: 28
 
 {
   "status" : "SUCCESS"
@@ -3401,14 +3285,14 @@ Content-Length: 26
 <div class="title">curl-request</div>
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/follows/2' -i -X GET \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njg0NzE2ODIsImV4cCI6MTY2ODQ3NTI4Mn0.oad5divFnBt6LGs4HRSASbJd2M2zWJjCNxaAR9bsK0Q'</code></pre>
+    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njg1NzcwNzEsImV4cCI6MTY2ODU4MDY3MX0.8tPLiVTzvZmvJfXoaiDwxkGNlJM8R5i42m2SfWCs9a8'</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">http-request</div>
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">GET /follows/2 HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njg0NzE2ODIsImV4cCI6MTY2ODQ3NTI4Mn0.oad5divFnBt6LGs4HRSASbJd2M2zWJjCNxaAR9bsK0Q
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njg1NzcwNzEsImV4cCI6MTY2ODU4MDY3MX0.8tPLiVTzvZmvJfXoaiDwxkGNlJM8R5i42m2SfWCs9a8
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -3470,7 +3354,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 21
+Content-Length: 23
 
 {
   "follow" : true
@@ -3512,14 +3396,14 @@ Content-Length: 21
 <div class="title">curl-request</div>
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/likes/10101' -i -X POST \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njg0NzE2ODIsImV4cCI6MTY2ODQ3NTI4Mn0.oad5divFnBt6LGs4HRSASbJd2M2zWJjCNxaAR9bsK0Q'</code></pre>
+    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njg1NzcwNzEsImV4cCI6MTY2ODU4MDY3MX0.8tPLiVTzvZmvJfXoaiDwxkGNlJM8R5i42m2SfWCs9a8'</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">http-request</div>
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">POST /likes/10101 HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njg0NzE2ODIsImV4cCI6MTY2ODQ3NTI4Mn0.oad5divFnBt6LGs4HRSASbJd2M2zWJjCNxaAR9bsK0Q
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njg1NzcwNzEsImV4cCI6MTY2ODU4MDY3MX0.8tPLiVTzvZmvJfXoaiDwxkGNlJM8R5i42m2SfWCs9a8
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -3581,7 +3465,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 26
+Content-Length: 28
 
 {
   "status" : "SUCCESS"
@@ -3617,14 +3501,14 @@ Content-Length: 26
 <div class="title">curl-request</div>
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/likes/10101' -i -X GET \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njg0NzE2ODIsImV4cCI6MTY2ODQ3NTI4Mn0.oad5divFnBt6LGs4HRSASbJd2M2zWJjCNxaAR9bsK0Q'</code></pre>
+    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njg1NzcwNzEsImV4cCI6MTY2ODU4MDY3MX0.8tPLiVTzvZmvJfXoaiDwxkGNlJM8R5i42m2SfWCs9a8'</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">http-request</div>
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">GET /likes/10101 HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njg0NzE2ODIsImV4cCI6MTY2ODQ3NTI4Mn0.oad5divFnBt6LGs4HRSASbJd2M2zWJjCNxaAR9bsK0Q
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njg1NzcwNzEsImV4cCI6MTY2ODU4MDY3MX0.8tPLiVTzvZmvJfXoaiDwxkGNlJM8R5i42m2SfWCs9a8
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -3686,7 +3570,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 20
+Content-Length: 22
 
 {
   "likes" : true
@@ -3722,7 +3606,7 @@ Content-Length: 20
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2022-11-15 09:20:36 +0900
+Last updated 2022-11-15 09:26:49 +0900
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prettify/r298/prettify.min.css">

--- a/back/src/test/java/travelRepo/domain/board/controller/BoardControllerTest.java
+++ b/back/src/test/java/travelRepo/domain/board/controller/BoardControllerTest.java
@@ -21,6 +21,7 @@ import travelRepo.global.security.jwt.JwtProcessor;
 
 import java.util.List;
 
+import static org.hamcrest.Matchers.hasSize;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
@@ -377,7 +378,7 @@ class BoardControllerTest {
     public void boardDetails_Success() throws Exception {
 
         // given
-        Long boardId = 1L;
+        Long boardId = 12001L;
 
         // when
         ResultActions actions = mockMvc.perform(
@@ -388,6 +389,17 @@ class BoardControllerTest {
         //then
         actions
                 .andExpect(status().isOk())
+                .andExpect(jsonPath("$.boardId").value(boardId))
+                .andExpect(jsonPath("$.title").value("testTitle"))
+                .andExpect(jsonPath("$.content").value("testContents"))
+                .andExpect(jsonPath("$.location").value("test-location"))
+                .andExpect(jsonPath("$.category").value("RESTAURANT"))
+                .andExpect(jsonPath("$.likeCount").value(1))
+                .andExpect(jsonPath("$.views").value(11))
+                .andExpect(jsonPath("$.tags", hasSize(2)))
+                .andExpect(jsonPath("$.photos", hasSize(3)))
+                .andExpect(jsonPath("$.createdAt").value("2022-10-14T12:00:01"))
+                .andExpect(jsonPath("$.account.accountId").value(10001))
                 .andDo(document(
                         "boardDetails",
                         getRequestPreProcessor(),
@@ -397,7 +409,6 @@ class BoardControllerTest {
                         ),
                         responseFields(
                                 List.of(
-                                        fieldWithPath("myBoard").type(JsonFieldType.BOOLEAN).description("로그인한 회원이 쓴 글일지 확인"),
                                         fieldWithPath("boardId").type(JsonFieldType.NUMBER).description("게시글 식별자"),
                                         fieldWithPath("title").type(JsonFieldType.STRING).description("게시글 제목"),
                                         fieldWithPath("content").type(JsonFieldType.STRING).description("게시글 내용"),
@@ -415,6 +426,26 @@ class BoardControllerTest {
                                 )
                         )
                 ));
+    }
+
+    @Test
+    @DisplayName("게시글 단일 조회_존재하지 않는 게시글")
+    public void boardDetails_NOT_FOUND() throws Exception {
+
+        // given
+        Long boardId = 12101L;
+
+        // when
+        ResultActions actions = mockMvc.perform(
+                get("/boards/{boardId}", boardId)
+                        .accept(MediaType.APPLICATION_JSON)
+        );
+
+        //then
+        actions
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.exception").value(BusinessLogicException.class.getSimpleName()))
+                .andExpect(jsonPath("$.message").value("게시글을 찾을 수 없습니다."));
     }
 
     @Test


### PR DESCRIPTION
1. 게시물 단일 조회 API를 구현했습니다. 
 - 게시물 조회 시 views가 변하기 때문에 LastmodifiedAt의 값이 변하지만 사용되는 부분이 없기 때문에 일단 그대로 뒀습니다.
 - 게시물 조회 시 해당 게시물이 로그인한 계정이 작성한 것인지 판별하는 myBoard 값을 응답 데이터에서 삭제했습니다.

2. 게시물 단일 조회 API 테스트 코드를 작성했습니다.

3. 응답 데이터에 변화가 있기 때문에 API 명세서를 최신화 했습니다.