### PR TITLE
[Feat] 댓글 등록 API 구현 및 테스트

### DIFF
--- a/back/src/main/java/travelRepo/domain/comment/controller/CommentController.java
+++ b/back/src/main/java/travelRepo/domain/comment/controller/CommentController.java
@@ -15,6 +15,7 @@ import travelRepo.domain.comment.service.CommentService;
 import travelRepo.global.argumentresolver.LoginAccountId;
 import travelRepo.global.common.dto.SliceDto;
 
+import javax.validation.Valid;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -28,7 +29,7 @@ public class CommentController {
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public void commentAdd(@RequestBody CommentAddReq commentAddReq,
+    public void commentAdd(@Valid @RequestBody CommentAddReq commentAddReq,
                            @LoginAccountId Long loginAccountId) {
 
         commentService.addComment(commentAddReq, loginAccountId);

--- a/back/src/main/java/travelRepo/domain/comment/controller/CommentController.java
+++ b/back/src/main/java/travelRepo/domain/comment/controller/CommentController.java
@@ -11,6 +11,8 @@ import travelRepo.domain.account.dto.AccountSummaryRes;
 import travelRepo.domain.comment.dto.CommentAddReq;
 import travelRepo.domain.comment.dto.CommentDetailsRes;
 import travelRepo.domain.comment.dto.CommentModifyReq;
+import travelRepo.domain.comment.service.CommentService;
+import travelRepo.global.argumentresolver.LoginAccountId;
 import travelRepo.global.common.dto.SliceDto;
 
 import java.time.LocalDateTime;
@@ -22,9 +24,14 @@ import java.util.List;
 @RequiredArgsConstructor
 public class CommentController {
 
+    private final CommentService commentService;
+
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public void commentAdd(@RequestBody CommentAddReq commentAddReq) {
+    public void commentAdd(@RequestBody CommentAddReq commentAddReq,
+                           @LoginAccountId Long loginAccountId) {
+
+        commentService.addComment(commentAddReq, loginAccountId);
     }
 
     @PatchMapping("/{commentId}")

--- a/back/src/main/java/travelRepo/domain/comment/dto/CommentAddReq.java
+++ b/back/src/main/java/travelRepo/domain/comment/dto/CommentAddReq.java
@@ -1,11 +1,30 @@
 package travelRepo.domain.comment.dto;
 
 import lombok.Data;
+import travelRepo.domain.account.entity.Account;
+import travelRepo.domain.board.entity.Board;
+import travelRepo.domain.comment.entity.Comment;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Positive;
 
 @Data
 public class CommentAddReq {
 
+    @NotNull
+    @Positive
     private Long boardId;
 
+    @NotBlank
     private String content;
+
+    public Comment toComment(Account account, Board board) {
+
+        return Comment.builder()
+                .account(account)
+                .board(board)
+                .content(content)
+                .build();
+    }
 }

--- a/back/src/main/java/travelRepo/domain/comment/entity/Comment.java
+++ b/back/src/main/java/travelRepo/domain/comment/entity/Comment.java
@@ -1,5 +1,7 @@
 package travelRepo.domain.comment.entity;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import travelRepo.domain.account.entity.Account;
@@ -10,7 +12,9 @@ import javax.persistence.*;
 
 @Entity
 @Getter
+@Builder
 @NoArgsConstructor
+@AllArgsConstructor
 public class Comment extends BaseTime {
 
     @Id

--- a/back/src/main/java/travelRepo/domain/comment/service/CommentService.java
+++ b/back/src/main/java/travelRepo/domain/comment/service/CommentService.java
@@ -1,0 +1,38 @@
+package travelRepo.domain.comment.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import travelRepo.domain.account.entity.Account;
+import travelRepo.domain.account.repository.AccountRepository;
+import travelRepo.domain.board.entity.Board;
+import travelRepo.domain.board.repository.BoardRepository;
+import travelRepo.domain.comment.dto.CommentAddReq;
+import travelRepo.domain.comment.entity.Comment;
+import travelRepo.domain.comment.repository.CommentRepository;
+import travelRepo.global.exception.BusinessLogicException;
+import travelRepo.global.exception.ExceptionCode;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CommentService {
+
+    private final CommentRepository commentRepository;
+    private final BoardRepository boardRepository;
+    private final AccountRepository accountRepository;
+
+    @Transactional
+    public void addComment(CommentAddReq commentAddReq, Long loginAccountId) {
+
+        Account account = accountRepository.findById(loginAccountId)
+                .orElseThrow(() -> new BusinessLogicException(ExceptionCode.NOT_FOUND_ACCOUNT));
+
+        Board board = boardRepository.findById(commentAddReq.getBoardId())
+                .orElseThrow(() -> new BusinessLogicException(ExceptionCode.NOT_FOUND_BOARD));
+
+        Comment comment = commentAddReq.toComment(account, board);
+
+        commentRepository.save(comment);
+    }
+}

--- a/back/src/main/java/travelRepo/global/exception/advice/ExceptionAdvice.java
+++ b/back/src/main/java/travelRepo/global/exception/advice/ExceptionAdvice.java
@@ -1,7 +1,6 @@
 package travelRepo.global.exception.advice;
 
 import org.springframework.validation.BindException;
-import org.springframework.web.bind.MethodArgumentNotValidException;
 import travelRepo.global.exception.BusinessLogicException;
 import travelRepo.global.exception.dto.ErrorResponse;
 import org.springframework.http.HttpStatus;

--- a/back/src/main/java/travelRepo/global/exception/advice/ExceptionAdvice.java
+++ b/back/src/main/java/travelRepo/global/exception/advice/ExceptionAdvice.java
@@ -1,6 +1,7 @@
 package travelRepo.global.exception.advice;
 
 import org.springframework.validation.BindException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import travelRepo.global.exception.BusinessLogicException;
 import travelRepo.global.exception.dto.ErrorResponse;
 import org.springframework.http.HttpStatus;
@@ -29,6 +30,13 @@ public class ExceptionAdvice {
 
     @ExceptionHandler
     public ResponseEntity<ErrorResponse> bindExceptionHandler(BindException e) {
+
+        ErrorResponse errorResponse = new ErrorResponse(e.getClass().getSimpleName(), "잘못된 입력값입니다.");
+        return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ErrorResponse> methodArgumentNotValidExceptionHandler(MethodArgumentNotValidException e) {
 
         ErrorResponse errorResponse = new ErrorResponse(e.getClass().getSimpleName(), "잘못된 입력값입니다.");
         return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);

--- a/back/src/main/java/travelRepo/global/exception/advice/ExceptionAdvice.java
+++ b/back/src/main/java/travelRepo/global/exception/advice/ExceptionAdvice.java
@@ -34,11 +34,4 @@ public class ExceptionAdvice {
         ErrorResponse errorResponse = new ErrorResponse(e.getClass().getSimpleName(), "잘못된 입력값입니다.");
         return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
     }
-
-    @ExceptionHandler
-    public ResponseEntity<ErrorResponse> methodArgumentNotValidExceptionHandler(MethodArgumentNotValidException e) {
-
-        ErrorResponse errorResponse = new ErrorResponse(e.getClass().getSimpleName(), "잘못된 입력값입니다.");
-        return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
-    }
 }


### PR DESCRIPTION
댓글 등록 API 와 테스트 코드를 작성했습니다.

댓글은 게시글과 다르게 JSON 형식으로 데이터를 받아 @RequestBody를 사용하기 때문에 MethodArgumentNotValidException룰 캐치할 수 있는 ExceptionHandler를 추가했습니다. 