### PR TITLE
[Feat] 댓글 조회 API 구현 및 테스트

### DIFF
--- a/back/src/main/java/travelRepo/domain/board/controller/BoardController.java
+++ b/back/src/main/java/travelRepo/domain/board/controller/BoardController.java
@@ -92,7 +92,7 @@ public class BoardController {
 
         SliceImpl<BoardSummaryRes> response = new SliceImpl<>(content, pageable, true);
 
-        return new ResponseEntity(new SliceDto(response), HttpStatus.OK);
+        return new ResponseEntity(new SliceDto(response, response.getContent()), HttpStatus.OK);
     }
 
     @GetMapping("/account/{accountId}")
@@ -121,6 +121,6 @@ public class BoardController {
 
         SliceImpl<BoardSummaryRes> response = new SliceImpl<>(content, pageable, false);
 
-        return new ResponseEntity(new SliceDto(response), HttpStatus.OK);
+        return new ResponseEntity(new SliceDto(response, response.getContent()), HttpStatus.OK);
     }
 }

--- a/back/src/main/java/travelRepo/domain/board/controller/BoardController.java
+++ b/back/src/main/java/travelRepo/domain/board/controller/BoardController.java
@@ -92,7 +92,7 @@ public class BoardController {
 
         SliceImpl<BoardSummaryRes> response = new SliceImpl<>(content, pageable, true);
 
-        return new ResponseEntity(new SliceDto(response, response.getContent()), HttpStatus.OK);
+        return new ResponseEntity(new SliceDto(response), HttpStatus.OK);
     }
 
     @GetMapping("/account/{accountId}")
@@ -121,6 +121,6 @@ public class BoardController {
 
         SliceImpl<BoardSummaryRes> response = new SliceImpl<>(content, pageable, false);
 
-        return new ResponseEntity(new SliceDto(response, response.getContent()), HttpStatus.OK);
+        return new ResponseEntity(new SliceDto(response), HttpStatus.OK);
     }
 }

--- a/back/src/main/java/travelRepo/domain/comment/controller/CommentController.java
+++ b/back/src/main/java/travelRepo/domain/comment/controller/CommentController.java
@@ -51,27 +51,10 @@ public class CommentController {
 
     @GetMapping("/board/{boardId}")
     public ResponseEntity<SliceDto<CommentDetailsRes>> commentList(@PathVariable Long boardId,
-                                                                   @PageableDefault(size = 5, sort = "createdAt,DESC") Pageable pageable) {
+                                                                   @PageableDefault(size = 10, sort = "createdAt") Pageable pageable) {
 
-        List<CommentDetailsRes> content = new ArrayList<>();
+        SliceDto<CommentDetailsRes> response = commentService.commentList(boardId, pageable);
 
-        for (int i = 1; i < 6; i++) {
-            AccountSummaryRes accountSummaryRes = new AccountSummaryRes();
-            accountSummaryRes.setAccountId(0L + i);
-            accountSummaryRes.setProfile("https://main-image-repo.s3.ap-northeast-2.amazonaws.com/%EC%83%88+%ED%8F%B4%EB%8D%94/" + i + ".png");
-            accountSummaryRes.setNickname("mockAccount" + i);
-
-            CommentDetailsRes commentDetailsRes = new CommentDetailsRes();
-            commentDetailsRes.setCommentId(0L + i);
-            commentDetailsRes.setContent("mock comment content" + i);
-            commentDetailsRes.setCreatedAt(LocalDateTime.now());
-            commentDetailsRes.setAccount(accountSummaryRes);
-
-            content.add(commentDetailsRes);
-        }
-
-        SliceImpl<CommentDetailsRes> response = new SliceImpl(content, pageable, true);
-
-        return new ResponseEntity(new SliceDto(response), HttpStatus.OK);
+        return new ResponseEntity(response, HttpStatus.OK);
     }
 }

--- a/back/src/main/java/travelRepo/domain/comment/controller/CommentController.java
+++ b/back/src/main/java/travelRepo/domain/comment/controller/CommentController.java
@@ -51,7 +51,7 @@ public class CommentController {
 
     @GetMapping("/board/{boardId}")
     public ResponseEntity<SliceDto<CommentDetailsRes>> commentList(@PathVariable Long boardId,
-                                                                   @PageableDefault(size = 10, sort = "createdAt") Pageable pageable) {
+                                                                   @PageableDefault(size = 5, sort = "createdAt") Pageable pageable) {
 
         SliceDto<CommentDetailsRes> response = commentService.commentList(boardId, pageable);
 

--- a/back/src/main/java/travelRepo/domain/comment/dto/CommentDetailsRes.java
+++ b/back/src/main/java/travelRepo/domain/comment/dto/CommentDetailsRes.java
@@ -2,6 +2,7 @@ package travelRepo.domain.comment.dto;
 
 import lombok.Data;
 import travelRepo.domain.account.dto.AccountSummaryRes;
+import travelRepo.domain.comment.entity.Comment;
 
 import java.time.LocalDateTime;
 
@@ -15,4 +16,15 @@ public class CommentDetailsRes {
     private LocalDateTime createdAt;
 
     private AccountSummaryRes account;
+
+    public static CommentDetailsRes of(Comment comment) {
+
+        CommentDetailsRes commentDetailsRes = new CommentDetailsRes();
+        commentDetailsRes.setCommentId(comment.getId());
+        commentDetailsRes.setContent(comment.getContent());
+        commentDetailsRes.setCreatedAt(comment.getCreatedAt());
+        commentDetailsRes.setAccount(AccountSummaryRes.of(comment.getAccount()));
+
+        return commentDetailsRes;
+    }
 }

--- a/back/src/main/java/travelRepo/domain/comment/repository/CommentRepository.java
+++ b/back/src/main/java/travelRepo/domain/comment/repository/CommentRepository.java
@@ -1,5 +1,7 @@
 package travelRepo.domain.comment.repository;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -24,4 +26,5 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     @Query("select c from Comment c where c.id = :commentId")
     Optional<Comment> findByIdWithAccount(@Param("commentId") Long commentId);
 
+    Slice<Comment> findAllByBoard_Id(Long boardsId, Pageable pageable);
 }

--- a/back/src/main/java/travelRepo/domain/comment/service/CommentService.java
+++ b/back/src/main/java/travelRepo/domain/comment/service/CommentService.java
@@ -1,6 +1,8 @@
 package travelRepo.domain.comment.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import travelRepo.domain.account.entity.Account;
@@ -8,11 +10,16 @@ import travelRepo.domain.account.repository.AccountRepository;
 import travelRepo.domain.board.entity.Board;
 import travelRepo.domain.board.repository.BoardRepository;
 import travelRepo.domain.comment.dto.CommentAddReq;
+import travelRepo.domain.comment.dto.CommentDetailsRes;
 import travelRepo.domain.comment.dto.CommentModifyReq;
 import travelRepo.domain.comment.entity.Comment;
 import travelRepo.domain.comment.repository.CommentRepository;
+import travelRepo.global.common.dto.SliceDto;
 import travelRepo.global.exception.BusinessLogicException;
 import travelRepo.global.exception.ExceptionCode;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -48,5 +55,15 @@ public class CommentService {
         }
 
         comment.modify(commentModifyReq.getContent());
+    }
+
+    public SliceDto<CommentDetailsRes> commentList(Long boardId, Pageable pageable) {
+
+        Slice<Comment> comments = commentRepository.findAllByBoard_Id(boardId, pageable);
+        List<CommentDetailsRes> content = comments.getContent().stream()
+                .map(CommentDetailsRes::of)
+                .collect(Collectors.toList());
+
+        return new SliceDto(comments, content);
     }
 }

--- a/back/src/main/java/travelRepo/domain/comment/service/CommentService.java
+++ b/back/src/main/java/travelRepo/domain/comment/service/CommentService.java
@@ -60,10 +60,7 @@ public class CommentService {
     public SliceDto<CommentDetailsRes> commentList(Long boardId, Pageable pageable) {
 
         Slice<Comment> comments = commentRepository.findAllByBoard_Id(boardId, pageable);
-        List<CommentDetailsRes> content = comments.getContent().stream()
-                .map(CommentDetailsRes::of)
-                .collect(Collectors.toList());
 
-        return new SliceDto(comments, content);
+        return new SliceDto(comments.map(CommentDetailsRes::of));
     }
 }

--- a/back/src/main/java/travelRepo/global/common/dto/SliceDto.java
+++ b/back/src/main/java/travelRepo/global/common/dto/SliceDto.java
@@ -19,8 +19,8 @@ public class SliceDto<T> {
 
     private int numberOfElements;
 
-    public SliceDto(Slice<T> slice, List<T> content) {
-        this.content = content;
+    public SliceDto(Slice<T> slice) {
+        this.content = slice.getContent();
         this.sliceNumber = slice.getNumber() + 1;
         this.size = slice.getSize();
         this.hasNext = slice.hasNext();

--- a/back/src/main/java/travelRepo/global/common/dto/SliceDto.java
+++ b/back/src/main/java/travelRepo/global/common/dto/SliceDto.java
@@ -19,9 +19,9 @@ public class SliceDto<T> {
 
     private int numberOfElements;
 
-    public SliceDto(Slice<T> slice) {
-        this.content = slice.getContent();
-        this.sliceNumber = slice.getNumber();
+    public SliceDto(Slice<T> slice, List<T> content) {
+        this.content = content;
+        this.sliceNumber = slice.getNumber() + 1;
         this.size = slice.getSize();
         this.hasNext = slice.hasNext();
         this.numberOfElements = slice.getNumberOfElements();

--- a/back/src/test/java/travelRepo/domain/comment/controller/CommentControllerTest.java
+++ b/back/src/test/java/travelRepo/domain/comment/controller/CommentControllerTest.java
@@ -23,6 +23,7 @@ import travelRepo.global.security.jwt.JwtProcessor;
 
 import java.util.List;
 
+import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
@@ -302,7 +303,7 @@ class CommentControllerTest {
     void commentList_Success() throws Exception {
 
         //given
-        Long boardId = 1l;
+        Long boardId = 12002l;
 
         //when
         ResultActions actions = mockMvc.perform(
@@ -313,6 +314,11 @@ class CommentControllerTest {
         //then
         actions
                 .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content", hasSize(5)))
+                .andExpect(jsonPath("$.sliceNumber").value(1))
+                .andExpect(jsonPath("$.size").value(5))
+                .andExpect(jsonPath("$.hasNext").value("true"))
+                .andExpect(jsonPath("$.numberOfElements").value(5))
                 .andDo(document(
                         "commentList",
                         getRequestPreProcessor(),

--- a/back/src/test/resources/static/db/data.sql
+++ b/back/src/test/resources/static/db/data.sql
@@ -26,6 +26,14 @@ INSERT INTO Likes(likes_id, createdAt, modifiedAt, account_id, board_id) VALUES(
 INSERT INTO Comment(comment_id, createdAt, modifiedAt, content, account_id, board_id) VALUES('15001', '2022-10-14 14:00:01', '2022-10-14 14:00:01', 'testContents', '10001', '12002');
 INSERT INTO Comment(comment_id, createdAt, modifiedAt, content, account_id, board_id) VALUES('15002', '2022-10-14 14:00:01', '2022-10-14 14:00:01', 'testContents', '10001', '12003');
 INSERT INTO Comment(comment_id, createdAt, modifiedAt, content, account_id, board_id) VALUES('15003', '2022-10-14 14:00:01', '2022-10-14 14:00:01', 'testContents', '10002', '12001');
+INSERT INTO Comment(comment_id, createdAt, modifiedAt, content, account_id, board_id) VALUES('15004', '2022-10-14 14:00:01', '2022-10-14 14:00:01', 'testContents', '10001', '12001');
+INSERT INTO Comment(comment_id, createdAt, modifiedAt, content, account_id, board_id) VALUES('15005', '2022-10-14 14:00:01', '2022-10-14 14:00:01', 'testContents', '10003', '12001');
+INSERT INTO Comment(comment_id, createdAt, modifiedAt, content, account_id, board_id) VALUES('15006', '2022-10-14 14:00:02', '2022-10-14 14:00:02', 'testContents', '10002', '12002');
+INSERT INTO Comment(comment_id, createdAt, modifiedAt, content, account_id, board_id) VALUES('15007', '2022-10-14 14:00:03', '2022-10-14 14:00:03', 'testContents', '10003', '12002');
+INSERT INTO Comment(comment_id, createdAt, modifiedAt, content, account_id, board_id) VALUES('15008', '2022-10-14 14:00:04', '2022-10-14 14:00:04', 'testContents', '10001', '12002');
+INSERT INTO Comment(comment_id, createdAt, modifiedAt, content, account_id, board_id) VALUES('15009', '2022-10-14 14:00:05', '2022-10-14 14:00:05', 'testContents', '10002', '12002');
+INSERT INTO Comment(comment_id, createdAt, modifiedAt, content, account_id, board_id) VALUES('15010', '2022-10-14 14:00:06', '2022-10-14 14:00:06', 'testContents', '10003', '12002');
+INSERT INTO Comment(comment_id, createdAt, modifiedAt, content, account_id, board_id) VALUES('15100', '2022-10-14 14:00:01', '2022-10-14 14:00:01', 'testContents', '10001', '12001');
 
 INSERT INTO Tag(tag_id, createdAt, modifiedAt, name) VALUES('16001', '2022-10-14 15:00:01', '2022-10-14 14:00:01', 'testName1');
 INSERT INTO Tag(tag_id, createdAt, modifiedAt, name) VALUES('16002', '2022-10-14 15:00:02', '2022-10-14 15:00:02', 'testName2');


### PR DESCRIPTION
특정 게시글의 전체 댓글을 조회할 수 있는 API를 구현/테스트 했습니다.
 - 기본적으로 5개 씩 조회할 수 있도록 했습니다 .
 - 생성 순 (오래된 댓글 순)으로 정렬되도록 했습니다.
 - boardId를 검증하는 로직은 넣지 않았습니다. 백엔드 쪽에서 검증하는 건 크게 의미 없고 프론트 쪽에서 주의해야 할 부분이라 생각합니다.