### PR TITLE
[Feat] 로그인 성공, 실패에 따른 분기 및 UI 추가, 임시 로그아웃 버튼 구현

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -21,6 +21,7 @@
         "react-redux": "^8.0.5",
         "react-router-dom": "^6.4.3",
         "react-scripts": "5.0.1",
+        "react-toastify": "^9.1.1",
         "react-uuid": "^2.0.0",
         "redux": "^4.2.0",
         "styled-components": "^5.3.6",
@@ -5550,6 +5551,14 @@
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/co": {
@@ -14135,6 +14144,18 @@
         "node": ">=10"
       }
     },
+    "node_modules/react-toastify": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-9.1.1.tgz",
+      "integrity": "sha512-pkFCla1z3ve045qvjEmn2xOJOy4ZciwRXm1oMPULVkELi5aJdHCN/FHnuqXq8IwGDLB7PPk2/J6uP9D8ejuiRw==",
+      "dependencies": {
+        "clsx": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
+      }
+    },
     "node_modules/react-uuid": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/react-uuid/-/react-uuid-2.0.0.tgz",
@@ -20957,6 +20978,11 @@
         "wrap-ansi": "^7.0.0"
       }
     },
+    "clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg=="
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -27109,6 +27135,14 @@
             "lru-cache": "^6.0.0"
           }
         }
+      }
+    },
+    "react-toastify": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-9.1.1.tgz",
+      "integrity": "sha512-pkFCla1z3ve045qvjEmn2xOJOy4ZciwRXm1oMPULVkELi5aJdHCN/FHnuqXq8IwGDLB7PPk2/J6uP9D8ejuiRw==",
+      "requires": {
+        "clsx": "^1.1.1"
       }
     },
     "react-uuid": {

--- a/front/package.json
+++ b/front/package.json
@@ -16,6 +16,7 @@
     "react-redux": "^8.0.5",
     "react-router-dom": "^6.4.3",
     "react-scripts": "5.0.1",
+    "react-toastify": "^9.1.1",
     "react-uuid": "^2.0.0",
     "redux": "^4.2.0",
     "styled-components": "^5.3.6",

--- a/front/src/App.js
+++ b/front/src/App.js
@@ -1,9 +1,11 @@
 import './App.css';
 import React, { useState, Suspense } from 'react';
 import { Route, Routes, BrowserRouter as Router } from 'react-router-dom';
+import { ToastContainer, toast } from 'react-toastify';
 import Loading from './component/common/Loading';
 import Header from './component/common/header/Header';
 import LoginModal from './component/common/modal/LoginModal';
+import 'react-toastify/dist/ReactToastify.css';
 
 const MainPage = React.lazy(() => import('./pages/MainPage'));
 const PublishPage = React.lazy(() => import('./pages/PublishPage'));
@@ -12,18 +14,37 @@ const PostDetailPage = React.lazy(() => import('./pages/PostDetailPage'));
 function App() {
   const [loginModalOpened, setLoginModalOpened] = useState(false);
 
+  // 로그인 모달 여닫는 함수
   const loginModalOpener = () => {
     setLoginModalOpened(true);
   };
-
   const loginModalCloser = () => {
     setLoginModalOpened(false);
   };
 
+  // 로그인 성공 시, toastify 함수
+  const loginNotify = () =>
+    toast('로그인 성공!', {
+      position: 'top-center',
+      autoClose: 2000,
+      hideProgressBar: false,
+      closeOnClick: true,
+      pauseOnHover: false,
+      draggable: true,
+      progress: undefined,
+      theme: 'light',
+    });
+
   return (
     <Router>
       <Suspense fallback={<Loading />}>
-        {loginModalOpened && <LoginModal modalCloser={loginModalCloser} />}
+        <ToastContainer />
+        {loginModalOpened && (
+          <LoginModal
+            modalCloser={loginModalCloser}
+            loginNotify={loginNotify}
+          />
+        )}
         <Header loginModalOpener={loginModalOpener} />
         <Routes>
           <Route path="/" element={<MainPage />} />

--- a/front/src/api/loginUserApi.js
+++ b/front/src/api/loginUserApi.js
@@ -1,0 +1,27 @@
+import axios from 'axios';
+import { getCookie } from '../util/cookie';
+
+// const accessToken = getCookie('accessToken');
+
+// const loginUserApi = async () => {
+//   return axios.get('/accounts/login', {
+//     headers: { Authorizaiotn: accessToken },
+//   });
+// };
+
+// export default loginUserApi;
+
+const loginUserApi = async () => {
+  const jwt = getCookie('accessToken');
+  const login = await axios.get('/accounts/login', {
+    headers: {
+      Authorization: jwt,
+    },
+  });
+  if (!localStorage.getItem('id') && !localStorage.getItem('profile')) {
+    localStorage.setItem('id', login.data.id);
+    localStorage.setItem('profile', login.data.profile);
+  }
+};
+
+export default loginUserApi;

--- a/front/src/component/common/header/HeaderUser.jsx
+++ b/front/src/component/common/header/HeaderUser.jsx
@@ -5,6 +5,7 @@ import { RiArrowDownSFill } from 'react-icons/ri';
 import { BiUserCircle } from 'react-icons/bi';
 import { useSelector } from 'react-redux';
 import { DefaultButton } from '../button/ButtonStyle';
+import { removeCookie } from '../../../util/cookie';
 
 const HeaderUserWrapper = styled.nav`
   width: 100%;
@@ -62,6 +63,12 @@ function HeaderUser({ loginModalOpener }) {
   const [rorate, setRorate] = useState('');
   const isLogin = useSelector(state => state.login.isLogin);
 
+  // 로그아웃 핸들러
+  const logoutHandler = () => {
+    removeCookie('accessToken');
+    window.location.href = '/';
+  };
+
   return (
     <HeaderUserWrapper>
       <button className="header__write">게시물 작성</button>
@@ -84,6 +91,8 @@ function HeaderUser({ loginModalOpener }) {
           </DefaultButton>
         ) : (
           <>
+            {/* 임시 로그아웃 버튼 */}
+            <button onClick={logoutHandler}>로그아웃</button>
             <BiUserCircle size="4.3rem" />
             <RiArrowDownSFill size="2.5rem" color="hsl(146, 50%, 50%)" />
           </>

--- a/front/src/component/common/header/HeaderUser.jsx
+++ b/front/src/component/common/header/HeaderUser.jsx
@@ -66,6 +66,8 @@ function HeaderUser({ loginModalOpener }) {
   // 로그아웃 핸들러
   const logoutHandler = () => {
     removeCookie('accessToken');
+    localStorage.removeItem('id');
+    localStorage.removeItem('profile');
     window.location.href = '/';
   };
 

--- a/front/src/component/common/modal/LoginModal.jsx
+++ b/front/src/component/common/modal/LoginModal.jsx
@@ -6,6 +6,7 @@ import Backdrop from './Backdrop';
 import { DefaultButton, TransparentButton } from '../button/ButtonStyle';
 import SignupModal from './SignupModal';
 import loginAsync from '../../../redux/action/loginAsync';
+import loginUserApi from '../../../api/loginUserApi';
 
 const LoginModalStyle = styled.div`
   display: flex;
@@ -88,6 +89,7 @@ function LoginModal({ modalCloser, loginNotify }) {
       // unwrap()을 해줘야만 비동기 처리가 제대로 작동함.
       await dispatch(loginAsync(data)).unwrap();
       setIsValidate(true);
+      loginUserApi();
       loginNotify();
       modalCloser();
     } catch (err) {

--- a/front/src/component/common/modal/LoginModal.jsx
+++ b/front/src/component/common/modal/LoginModal.jsx
@@ -58,7 +58,7 @@ const LoginModalStyle = styled.div`
   }
 `;
 
-function LoginModal({ modalCloser }) {
+function LoginModal({ modalCloser, loginNotify }) {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [signupModalOpened, setSignupModalOpened] = useState(false);
@@ -88,6 +88,7 @@ function LoginModal({ modalCloser }) {
       // unwrap()을 해줘야만 비동기 처리가 제대로 작동함.
       await dispatch(loginAsync(data)).unwrap();
       setIsValidate(true);
+      loginNotify();
       modalCloser();
     } catch (err) {
       console.log(err.response.data.code);

--- a/front/src/redux/action/loginAsync.js
+++ b/front/src/redux/action/loginAsync.js
@@ -1,10 +1,17 @@
 import { createAsyncThunk } from '@reduxjs/toolkit';
 import loginApi from '../../api/loginApi';
 
-const loginAsync = createAsyncThunk('login/loginAsync', async data => {
-  const loginData = await loginApi(data);
-
-  return loginData;
-});
+const loginAsync = createAsyncThunk(
+  'login/loginAsync',
+  async (data, { rejectWithValue }) => {
+    try {
+      const loginData = await loginApi(data);
+      return loginData;
+    } catch (err) {
+      // rejectWithValue 함수에 err를 담지 않으면 에러 데이터가 직렬화되지 못함.
+      return rejectWithValue(err);
+    }
+  },
+);
 
 export default loginAsync;

--- a/front/src/redux/loginSlice.js
+++ b/front/src/redux/loginSlice.js
@@ -18,9 +18,7 @@ const loginSlice = createSlice({
     },
   },
   extraReducers: {
-    [loginAsync.pending]: (state, action) => {
-      console.log(state, action);
-    },
+    [loginAsync.pending]: () => {},
     [loginAsync.fulfilled]: (state, action) => {
       state.isLogin = true;
       // state.accessToken = action.payload.headers.authorization;
@@ -33,11 +31,8 @@ const loginSlice = createSlice({
         sameSite: 'None',
         secure: 'false',
       });
-      console.log(state, action);
     },
-    [loginAsync.rejected]: (state, action) => {
-      console.log(state, action);
-    },
+    [loginAsync.rejected]: () => {},
   },
 });
 

--- a/front/src/redux/store.js
+++ b/front/src/redux/store.js
@@ -8,6 +8,11 @@ const reducer = {
 
 const store = configureStore({
   reducer,
+  // 직렬화 오류를 무시하기 위한 미들웨어
+  middleware: getDefaultMiddleware =>
+    getDefaultMiddleware({
+      serializableCheck: false,
+    }),
   devTools: true,
 });
 

--- a/front/src/util/cookie.js
+++ b/front/src/util/cookie.js
@@ -9,3 +9,7 @@ export const setCookie = (name, value, option) => {
 export const getCookie = name => {
   return cookies.get(name);
 };
+
+export const removeCookie = (name, option) => {
+  return cookies.remove(name, { option });
+};


### PR DESCRIPTION
로그인 성공과 실패에 따른 응답을 서버에서 받아 알맞은 UI를 출력하도록 했습니다.
로그인 성공시 헤더에 임시로 사용할 로그아웃 버튼을 달아놓았습니다.
로그인에 성공하면 jwt가 세션 쿠키에 담깁니다.
토큰이 필요한 요청을 보내실 때 꺼내 쓰시면 됩니다.