### PR TITLE
[Feat] 게시글 작성 페이지 이미지 미리보기

### DIFF
--- a/front/src/component/publish/PublishForm.jsx
+++ b/front/src/component/publish/PublishForm.jsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import { useNavigate } from 'react-router-dom';
 import categoryData from './categoryData';
 import { DefaultButton, TransparentButton } from '../common/button/ButtonStyle';
+import PublishPhoto from './PublishPhoto';
 
 // 컨테이너
 const Container = styled.div`
@@ -42,30 +43,6 @@ const Container = styled.div`
       color: var(--font-base-black);
       font-size: var(--font-15);
       font-weight: var(--font-semi-bold);
-    }
-  }
-`;
-
-// 사진 - 미구현(임시)
-const PhotoContainer = styled.section`
-  display: flex;
-  flex-wrap: nowrap;
-  gap: 2vw;
-  @media screen and (max-width: 549px) {
-    width: 100%;
-    justify-content: space-between;
-  }
-  .mock-photo {
-    display: flex;
-    width: 10rem;
-    height: 10rem;
-    border: 2px dashed burlywood;
-    border-radius: 10px;
-    margin-bottom: 2px;
-    @media screen and (max-width: 549px) {
-      width: 30vh;
-      height: 25vw;
-      flex-basis: 30%;
     }
   }
 `;
@@ -204,7 +181,7 @@ const TagWrapper = styled.ul`
       }
     }
   }
-  .tag__input-create {
+  .tag__input--create {
     border: none;
     flex: 1;
   }
@@ -297,15 +274,7 @@ function PublishForm() {
   return (
     <Container>
       <h1>새 게시물</h1>
-      <div className="temporary">
-        <PhotoContainer>
-          <div className="mock-photo" />
-          <div className="mock-photo" />
-          <div className="mock-photo" />
-        </PhotoContainer>
-        <small>*(임시) 업로드 가능한 파일 포맷은 jpg, png입니다.</small>
-      </div>
-
+      <PublishPhoto />
       <TitleContainer>
         <div className="title__label">
           <label htmlFor="title">제목</label>

--- a/front/src/component/publish/PublishPhoto.jsx
+++ b/front/src/component/publish/PublishPhoto.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { BsCamera } from 'react-icons/bs';
+import { AiOutlineDelete } from 'react-icons/ai';
 
 const Container = styled.section`
   display: flex;
@@ -79,6 +80,11 @@ function PublishPhoto() {
     setPhotos(uploaded);
   };
 
+  // 미리보기 사진 삭제
+  const deletePhotos = async () => {
+    setPhotos([]);
+  };
+
   // 메모리 누수 방지
   useEffect(() => {
     return () => {
@@ -120,6 +126,7 @@ function PublishPhoto() {
         <span className="footer">
           업로드 가능한 파일 포맷은 jpg, jpeg, png입니다.
         </span>
+        <AiOutlineDelete className="delete__button" onClick={deletePhotos} />
       </div>
     </Container>
   );

--- a/front/src/component/publish/PublishPhoto.jsx
+++ b/front/src/component/publish/PublishPhoto.jsx
@@ -82,6 +82,7 @@ function PublishPhoto() {
 
   // 미리보기 사진 삭제
   const deletePhotos = async () => {
+    URL.revokeObjectURL(photos);
     setPhotos([]);
   };
 

--- a/front/src/component/publish/PublishPhoto.jsx
+++ b/front/src/component/publish/PublishPhoto.jsx
@@ -46,6 +46,19 @@ const Container = styled.section`
     border: 2px dashed var(--holder-base-color);
     border-radius: 10px;
   }
+
+  @media screen and (max-width: 549px) {
+    width: 100%;
+    justify-content: space-between;
+    .uploader__default,
+    .upload__button--wrapper {
+      width: 10rem;
+      height: 10rem;
+    }
+    .uploader__preview {
+      margin-right: 0;
+    }
+  }
 `;
 
 const CameraIcon = styled(BsCamera)`

--- a/front/src/component/publish/PublishPhoto.jsx
+++ b/front/src/component/publish/PublishPhoto.jsx
@@ -1,0 +1,107 @@
+import { useState } from 'react';
+import styled from 'styled-components';
+import { BsCamera } from 'react-icons/bs';
+
+const Container = styled.section`
+  display: flex;
+  flex-direction: column;
+  flex-wrap: nowrap;
+
+  .uploader__container {
+    display: flex;
+    width: 100%;
+    height: 100%;
+    flex-wrap: nowrap;
+  }
+
+  .uploader__default {
+    display: flex;
+    width: 10rem;
+    height: 10rem;
+    border: 2px dashed var(--holder-base-color);
+    border-radius: 1rem;
+  }
+
+  .uploader__preview {
+    background-size: cover;
+    width: 10rem;
+    height: 10rem;
+    border-radius: 1rem;
+    margin-right: 1.5rem;
+  }
+
+  .upload__button--wrapper {
+    width: 10rem;
+    border-radius: 1rem;
+    border: 2px dashed var(--holder-base-color);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+
+  #upload__button {
+    display: none;
+    width: 10rem;
+    height: 10rem;
+    border: 2px dashed var(--holder-base-color);
+    border-radius: 10px;
+  }
+`;
+
+const CameraIcon = styled(BsCamera)`
+  color: var(--holder-base-color);
+  font-size: 3rem;
+`;
+
+function PublishPhoto() {
+  const [photos, setPhotos] = useState([]);
+
+  // 미리보기 사진 띄우기 - 클라이언트 메모리로 처리
+  const uploadPhotos = async event => {
+    const uploaded = [...photos];
+    const targetFiles = [...event.target.files]; // 등록 사진
+    targetFiles.map(obj => {
+      return uploaded.push(URL.createObjectURL(obj)); // Blob 객체를 URL로 바꾸어 img src로 mapping
+    });
+    setPhotos(uploaded);
+  };
+
+  return (
+    <Container>
+      <div className="uploader__container">
+        {photos.length === 0 ? (
+          <div className="uploader__default" />
+        ) : (
+          <div>
+            {photos.map(url => (
+              <img src={url} alt="photos" className="uploader__preview" />
+            ))}
+          </div>
+        )}
+        <div
+          className="upload__button--wrapper"
+          style={{ display: photos.length === 5 ? 'none' : 'block' }}
+        >
+          <div>
+            <label htmlFor="upload__button">
+              <CameraIcon />
+            </label>
+            <input
+              id="upload__button"
+              type="file"
+              onChange={uploadPhotos}
+              accept="image/jpg, image/png, image/jpeg"
+            />
+          </div>
+        </div>
+      </div>
+      <div>
+        <span className="footer">
+          업로드 가능한 파일 포맷은 jpg, jpeg, png입니다.
+        </span>
+      </div>
+    </Container>
+  );
+}
+
+export default PublishPhoto;

--- a/front/src/component/publish/PublishPhoto.jsx
+++ b/front/src/component/publish/PublishPhoto.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { BsCamera } from 'react-icons/bs';
 
@@ -65,6 +65,14 @@ function PublishPhoto() {
     });
     setPhotos(uploaded);
   };
+
+  // 메모리 누수 방지
+  useEffect(() => {
+    return () => {
+      return URL.revokeObjectURL(photos);
+      // 페이지 전환시 URL이 메모리에 남지 않도록 전부 폐기
+    };
+  }, []);
 
   return (
     <Container>


### PR DESCRIPTION
사진 업로드 시 blob의 url을 임시 생성해 로컬에서 미리보기를 보여줍니다.

FileReader라는 메서드도 있는데 base64 방식이라 createObjectUrl 썼습니다.
속도는 빠르지만 일일이 메모리에서 삭제 해줘야하는 번거로움이 있어요ㅠㅠ

여튼 현재는 유저 윈도우 메모리 활용하는 방식인데 나중에 서버 전송이 추가된다면
각 img요소의 src속성을 임시 url => 백엔드 url로 대체하면 되지 않을까? 생각하고 있습니다..

라이브러리 없이 해보려니 어렵네요 많은 도움 부탁드려요!

TODO : 서버 전송, 에러 처리(갯수/사이즈 등), 삭제버튼 개별 적용, 버그 픽스, CSS 🥶..