### PR TITLE
[Feat] 게시글 상세화면 로그인 여부에 따른 로직 구현

### DIFF
--- a/front/src/api/hookApi.js
+++ b/front/src/api/hookApi.js
@@ -1,9 +1,9 @@
 import axios from 'axios';
 
-const hookeAxios = async url => {
+const hookAxios = async url => {
   const data = await axios.get(url);
 
   return data;
 };
 
-export default hookeAxios;
+export default hookAxios;

--- a/front/src/api/hookApi.js
+++ b/front/src/api/hookApi.js
@@ -1,0 +1,9 @@
+import axios from 'axios';
+
+const hookeAxios = async url => {
+  const data = await axios.get(url);
+
+  return data;
+};
+
+export default hookeAxios;

--- a/front/src/api/postDetailApi.js
+++ b/front/src/api/postDetailApi.js
@@ -1,0 +1,94 @@
+import axios from 'axios';
+import { getCookie } from '../util/cookie';
+// 게시글 단일 조회시 필요한 정보 요청 API
+
+const jwt = getCookie('accessToken');
+const authHeader = {
+  headers: {
+    Authorization: jwt,
+  },
+};
+// 비로그인 게시글 상세화면 요청
+export const postDetailApi = async boardId => {
+  console.log(boardId);
+  const postDetail = await axios.get(`/boards/${boardId}`); // ${boardId};
+
+  const board = {
+    post: postDetail.data,
+  };
+  return board;
+};
+// 로그인 유저시 게시글 상세화면 요청
+export const postDetailUserApi = async (boardId, accountId) => {
+  // 게시글 단일 조회 Api
+  const postDetail = await axios.get(`/boards/${boardId}`); // ${boardId}
+  // 좋아요 조회 Api
+  const like = axios.get(`/likes/${boardId}`, authHeader);
+  // 팔로우 조회 Api
+  const follow = axios.get(
+    `/follows/${postDetail.data.account.accountId}`,
+    authHeader,
+  );
+
+  const data = await Promise.all([like, follow]);
+
+  const board = {
+    post: postDetail.data,
+    like: data[0].data,
+    follow: data[1].data,
+    self: accountId === postDetail.data.account.accountId,
+  };
+  return board;
+};
+// 게시물 삭제 Api
+export const postDetailDeleteApi = async boardId => {
+  const data = await axios.delete(`/boards${boardId}`, {}, authHeader);
+
+  return data;
+};
+
+// 게시글 댓글 조회
+export const postDetailCommentApi = async boardId => {
+  const comment = await axios.get(`/comments/board/${boardId}`);
+
+  console.log(comment);
+  return comment;
+};
+// 게시글 상세화면 댓글 입력
+export const postDetailCommentSubmitApi = async (boardId, comment) => {
+  const status = await axios.post(
+    '/comments',
+    { boardId, content: comment },
+    authHeader,
+  );
+  console.log(status);
+  return status;
+};
+// 댓글 수정 Api
+export const postDetailCommentModifyApi = async (commentId, content) => {
+  const status = await axios.patch(
+    `/comments/${commentId}`,
+    { content },
+    authHeader,
+  );
+  console.log(status);
+  return status;
+};
+// 댓글 삭제 Api
+export const postDetaulCommentDeleteApi = async commentId => {
+  const status = await axios.delete(`/comments${commentId}`, authHeader);
+  console.log(status);
+  return status;
+};
+
+// 팔로우 및 팔로우 취소 Api
+export const postDetailFollowApi = async accoundId => {
+  const follow = await axios.post(`/follows/${accoundId}`, {}, authHeader);
+  return follow.data.status;
+};
+
+// 좋아요 체크 및 취소 Api
+export const postDetailLikeApi = async boardId => {
+  const like = await axios.post(`/likes/${boardId}`, {}, authHeader);
+  return like.data.status;
+};

--- a/front/src/component/common/like/Like.jsx
+++ b/front/src/component/common/like/Like.jsx
@@ -18,6 +18,7 @@ const LikeImg = styled(AiFillHeart)`
   stroke: ${props => (props.color ? '' : `var(--font-tag-color)`)};
   stroke-width: 60px;
   margin-right: ${props => props.marginright};
+  cursor: pointer;
 `;
 
 function Like({ width, height, color, ment, size, marginright }) {

--- a/front/src/component/common/modal/LoginModal.jsx
+++ b/front/src/component/common/modal/LoginModal.jsx
@@ -92,6 +92,7 @@ function LoginModal({ modalCloser, loginNotify }) {
       loginUserApi();
       loginNotify();
       modalCloser();
+      window.location.reload();
     } catch (err) {
       console.log(err.response.data.code);
       // 유효성 검사

--- a/front/src/component/postDetail/PostDetailMain.jsx
+++ b/front/src/component/postDetail/PostDetailMain.jsx
@@ -1,7 +1,12 @@
 import styled from 'styled-components';
+// import { useNavigate } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
 import PostDetailPhoto from './PostDetailPhoto';
 import PostDetailArticle from './PostDetailArticle';
 import Comment from './comment/Comment';
+import Loading from '../common/Loading';
+import { postDetailApi, postDetailUserApi } from '../../api/postDetailApi';
 
 const Container = styled.main`
   height: 100%;
@@ -35,17 +40,63 @@ const Container = styled.main`
 `;
 
 function PostDetailMain() {
+  const boardId = useParams();
+  const [postDetail, setPostDetail] = useState('');
+  const [loading, setLoading] = useState(true);
+  const accountId = localStorage.getItem('id');
+  useEffect(() => {
+    if (accountId) {
+      postDetailUserApi(boardId.id, accountId)
+        .then(res => {
+          setPostDetail({
+            post: res.post,
+            userlike: res.like,
+            userfollow: res.follow,
+            self: res.self,
+          });
+          setLoading(false);
+        })
+        .catch(err => {
+          console.log(err);
+        });
+    } else {
+      postDetailApi(boardId.id)
+        .then(res => {
+          setPostDetail({
+            post: res.post,
+            userlike: '',
+            userfollow: '',
+            self: '',
+          });
+          setLoading(false);
+        })
+        .catch(err => {
+          console.log(err);
+        });
+    }
+  }, []);
+
   return (
     <Container>
-      <div className="detail__container">
-        <div className="detail__body">
-          <PostDetailPhoto />
-          <PostDetailArticle />
+      {loading ? (
+        <Loading />
+      ) : (
+        <div className="detail__container">
+          <div className="detail__body">
+            <PostDetailPhoto photos={postDetail.post.photos} />
+            <PostDetailArticle
+              post={postDetail.post}
+              userLike={postDetail.userlike}
+              userFollow={postDetail.userfollow}
+              self={postDetail.self}
+              board={boardId.id}
+            />
+          </div>
+          <div className="detail__comment">
+            <Comment />
+          </div>
         </div>
-        <div className="detail__comment">
-          <Comment />
-        </div>
-      </div>
+      )}
     </Container>
   );
 }

--- a/front/src/hooks/useAxios.jsx
+++ b/front/src/hooks/useAxios.jsx
@@ -1,0 +1,22 @@
+import { useEffect, useState } from 'react';
+import hookeAxios from '../api/hookApi';
+
+const useAxios = url => {
+  const [data, setData] = useState('');
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(true);
+  useEffect(() => {
+    hookeAxios(url)
+      .then(res => {
+        setData(res.data);
+        setLoading(false);
+      })
+      .catch(err => {
+        setError(err.response.data);
+      });
+  }, [url]);
+
+  return [data, loading, error];
+};
+
+export default useAxios;

--- a/front/src/hooks/useAxios.jsx
+++ b/front/src/hooks/useAxios.jsx
@@ -1,12 +1,12 @@
 import { useEffect, useState } from 'react';
-import hookeAxios from '../api/hookApi';
+import hookAxios from '../api/hookApi';
 
 const useAxios = url => {
   const [data, setData] = useState('');
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(true);
   useEffect(() => {
-    hookeAxios(url)
+    hookAxios(url)
       .then(res => {
         setData(res.data);
         setLoading(false);

--- a/front/src/hooks/useInput.jsx
+++ b/front/src/hooks/useInput.jsx
@@ -1,0 +1,17 @@
+import { useState } from 'react';
+
+const useInput = init => {
+  const [value, setValue] = useState(init);
+
+  const changeValue = e => {
+    setValue(e.target.value);
+  };
+
+  const resetValue = reset => {
+    setValue(reset);
+  };
+
+  return [value, changeValue, resetValue];
+};
+
+export default useInput;


### PR DESCRIPTION
### 작업목록
1. 로그인 모달 페이지 리로딩 추가
2. 커스텀 훅 useInput, useAxios 추가
3. 상세화면 로그인 여부에 따른 좋아요 및 팔로우 기능 사용 및 금지
4. 게시글 삭제 로직

### 추후 작업목록
1. 사용자 프로필 클릭 시 사용자의 계정으로 이동
2. 태그 클릭 시 해당 태크로 검색
3. toast 로 추후 에러 로직 처리