### PR TITLE
[Fix] 게시글에 태그/사진 추가 로직 수정

### DIFF
--- a/back/src/main/java/travelRepo/domain/board/dto/BoardAddReq.java
+++ b/back/src/main/java/travelRepo/domain/board/dto/BoardAddReq.java
@@ -2,7 +2,6 @@ package travelRepo.domain.board.dto;
 
 import lombok.Data;
 import org.hibernate.validator.constraints.Length;
-import org.springframework.web.multipart.MultipartFile;
 import travelRepo.domain.account.entity.Account;
 import travelRepo.domain.board.entity.Board;
 import travelRepo.domain.board.entity.Category;

--- a/back/src/main/java/travelRepo/domain/board/service/BoardService.java
+++ b/back/src/main/java/travelRepo/domain/board/service/BoardService.java
@@ -143,7 +143,9 @@ public class BoardService {
                 .map((tagName -> {
 
                     Tag tag = findTag(tagName);
-                    BoardTag boardTag = boardTagRepository.findByBoardIdAndTagId(board.getId(), tag.getId())
+                    BoardTag boardTag = board.getBoardTags().stream()
+                            .filter(bt -> bt.getTag().getName().equals(tagName))
+                            .findAny()
                             .orElseGet(() -> {
                                 return BoardTag.builder()
                                         .tag(tag)
@@ -163,7 +165,9 @@ public class BoardService {
         List<BoardPhoto> boardPhotos = images.stream()
                 .map(image -> {
 
-                    BoardPhoto boardPhoto = boardPhotoRepository.findByBoardIdAndPhoto(board.getId(), image)
+                    BoardPhoto boardPhoto = board.getBoardPhotos().stream()
+                            .filter(bp -> bp.getPhoto().equals(image))
+                            .findAny()
                             .orElseGet(() -> {
                                 return BoardPhoto.builder()
                                         .photo(image)

--- a/back/src/main/java/travelRepo/domain/board/service/BoardService.java
+++ b/back/src/main/java/travelRepo/domain/board/service/BoardService.java
@@ -6,7 +6,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
 import travelRepo.domain.account.entity.Account;
 import travelRepo.domain.account.repository.AccountRepository;
 import travelRepo.domain.board.dto.BoardAddReq;

--- a/back/src/main/java/travelRepo/domain/comment/service/CommentService.java
+++ b/back/src/main/java/travelRepo/domain/comment/service/CommentService.java
@@ -18,9 +18,6 @@ import travelRepo.global.common.dto.SliceDto;
 import travelRepo.global.exception.BusinessLogicException;
 import travelRepo.global.exception.ExceptionCode;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)


### PR DESCRIPTION
Board 에 태그/ 사진 추가 시 재사용 검증 로직에서 BoardTag와 BoardPhoto를 db가 아닌 Board에 있는 list에서 조회하도록 수정했습니다. 