### PR TITLE
[Feat] Post 태그 개수 제한

### DIFF
--- a/front/src/component/common/Post.jsx
+++ b/front/src/component/common/Post.jsx
@@ -105,6 +105,12 @@ const PostWrapper = styled.div`
             -webkit-line-clamp: 1;
             -webkit-box-orient: vertical;
             word-break: break-all;
+
+            @media screen and (max-width: 1621px) {
+              &:last-child {
+                display: none;
+              }
+            }
           }
         }
         .post__info {
@@ -162,11 +168,13 @@ function Post({ post }) {
           <div className="post__tw">
             {/* tag && user */}
             <ul className="post__tags">
-              {post.tags.map(tag => (
-                <li key={uuid()} className="post__tag">
-                  #{tag}
-                </li>
-              ))}
+              {post.tags.map((tag, idx) => {
+                return idx < 3 ? (
+                  <li key={uuid()} className="post__tag">
+                    #{tag}
+                  </li>
+                ) : null;
+              })}
             </ul>
             <div className="post__info">
               <span className="post__avatar">

--- a/front/src/component/common/header/Search.jsx
+++ b/front/src/component/common/header/Search.jsx
@@ -17,8 +17,14 @@ const SearchInput = styled.input`
   border: 1px solid var(--font-base-grey);
   padding-left: 2rem;
   padding-right: 5rem;
+  outline: none;
   @media screen and (max-width: 549px) {
     height: 3.5rem;
+  }
+  :focus {
+    box-shadow: 0px 0px 2px 2px rgb(64 191 119 / 25%);
+    border: 1px solid var(--button-theme);
+    transition: all 0.2s;
   }
 `;
 


### PR DESCRIPTION
태그 개수 제한을 빠뜨려서 추가했습니다. 
기존에는 화면을 줄일 경우 말줄임이 표시되도록 되어있었지만, 말줄임이 되는 것 보다는 태그 개수를 2개까지만 보여주는 것이 낫다고 생각하여 1621px 이하부터는 2개만 표시되도록 했습니다. 혹시 의견 있으시면 말씀해주세용!

- Post 태그 개수를 최대 3개까지 표시
- 1621px 이하에서는 최대 2개까지 표시
- 검색창 focus 효과 추가

 검색창 focus 효과는 header 수정하면서 빠뜨려서 함께 적용했습니다.