### PR TITLE
[Fix] 게시글이 삭제되지 않는 오류 수정

### DIFF
--- a/back/src/main/java/travelRepo/domain/board/repository/BoardPhotoRepository.java
+++ b/back/src/main/java/travelRepo/domain/board/repository/BoardPhotoRepository.java
@@ -13,7 +13,7 @@ public interface BoardPhotoRepository extends JpaRepository<BoardPhoto, Long> {
             "where boardPhoto.board in (select board from Board board where board.account.id = :accountId)")
     void deleteByAccountId(@Param("accountId") Long accountId);
 
-    @Modifying(flushAutomatically = true)
+    @Modifying(clearAutomatically = true)
     @Query("delete from BoardPhoto boardPhoto where boardPhoto.board.id = :boardId")
     void deleteByBoardId(@Param("boardId") Long boardId);
 }

--- a/back/src/main/java/travelRepo/domain/board/repository/BoardTagRepository.java
+++ b/back/src/main/java/travelRepo/domain/board/repository/BoardTagRepository.java
@@ -13,7 +13,7 @@ public interface BoardTagRepository extends JpaRepository<BoardTag, Long> {
             "in (select board from Board board where board.account.id = :accountId)")
     void deleteByAccountId(@Param("accountId") Long accountId);
 
-    @Modifying(flushAutomatically = true)
+    @Modifying(clearAutomatically = true)
     @Query("delete from BoardTag boardTag where boardTag.board.id = :boardId")
     void deleteByBoardId(@Param("boardId") Long boardId);
 }

--- a/back/src/main/java/travelRepo/domain/comment/repository/CommentRepository.java
+++ b/back/src/main/java/travelRepo/domain/comment/repository/CommentRepository.java
@@ -18,7 +18,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
             "or comment.board in (select board from Board board where board.account.id = :accountId)")
     void deleteByAccountId(@Param("accountId") Long accountId);
 
-    @Modifying(flushAutomatically = true)
+    @Modifying(clearAutomatically = true)
     @Query("delete from Comment comment where comment.board.id = :boardId")
     void deleteByBoardId(@Param("boardId") Long boardId);
 

--- a/back/src/main/java/travelRepo/domain/likes/likesRepository/LikesRepository.java
+++ b/back/src/main/java/travelRepo/domain/likes/likesRepository/LikesRepository.java
@@ -17,7 +17,7 @@ public interface LikesRepository extends JpaRepository<Likes, Long> {
             "or likes.board in (select board from Board board where board.account.id = :accountId)")
     void deleteByAccountId(@Param("accountId") Long accountId);
 
-    @Modifying(flushAutomatically = true)
+    @Modifying(clearAutomatically = true)
     @Query("delete from Likes likes where likes.board.id = :boardId")
     void deleteByBoardId(@Param("boardId") Long BoardId);
 


### PR DESCRIPTION
@Modifying 어노테이션의 attribute를 수정하면서 게시글이 삭제되지 않는 문제가 있었습니다.

clearAutomatically이 필요하지 않아보여 삭제했었는데 orphanRemoval 옵션과 문제가 생겨 다시 넣어주었습니다.