### PR TITLE
[Fix] 태그가 1개일 때 사라지는 버그 수정

### DIFF
--- a/front/src/component/common/Post.jsx
+++ b/front/src/component/common/Post.jsx
@@ -107,7 +107,7 @@ const PostWrapper = styled.div`
             word-break: break-all;
 
             @media screen and (max-width: 1621px) {
-              &:last-child {
+              &:nth-child(3) {
                 display: none;
               }
             }


### PR DESCRIPTION
게시물의 태그가 1개만 있는 경우 화면을 줄일 때 메인페이지의 Post의 태그가 사라지는 버그를 수정했습니다.