### PR TITLE
[Refactor] 좋아요한 게시글 조회 API 로직 변경/ 테스트/ API 문서화

### DIFF
--- a/back/src/docs/asciidoc/index.adoc
+++ b/back/src/docs/asciidoc/index.adoc
@@ -250,6 +250,22 @@ include::{snippets}/accountBoardList/http-response.adoc[]
 .response-fields
 include::{snippets}/accountBoardList/response-fields.adoc[]
 
+=== 좋아요한 게시글 조회
+.curl-request
+include::{snippets}/likeBoardList/curl-request.adoc[]
+
+.http-request
+include::{snippets}/likeBoardList/http-request.adoc[]
+
+.path-parameters
+include::{snippets}/likeBoardList/path-parameters.adoc[]
+
+.http-response
+include::{snippets}/likeBoardList/http-response.adoc[]
+
+.response-fields
+include::{snippets}/likeBoardList/response-fields.adoc[]
+
 ***
 == CommentController
 === 댓글 등록

--- a/back/src/main/java/travelRepo/domain/board/controller/BoardController.java
+++ b/back/src/main/java/travelRepo/domain/board/controller/BoardController.java
@@ -81,7 +81,7 @@ public class BoardController {
 
     @GetMapping("/like/account/{accountId}")
     public ResponseEntity<SliceDto<BoardSummaryRes>> likeBoardList(@PathVariable Long accountId,
-                                                                   @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+                                                                   @PageableDefault(size = 20) Pageable pageable) {
 
         SliceDto<BoardSummaryRes> response = boardService.findBoardsByLikes(accountId, pageable);
 

--- a/back/src/main/java/travelRepo/domain/board/repository/BoardRepository.java
+++ b/back/src/main/java/travelRepo/domain/board/repository/BoardRepository.java
@@ -25,6 +25,10 @@ public interface BoardRepository extends JpaRepository<Board, Long>, BoardReposi
     @Query("select b from Board b where b.account.id = :accountId")
     Slice<Board> findAllByAccountIdWithBoardTagsAndAccount(@Param("accountId") Long accountId, Pageable pageable);
 
+    @EntityGraph(attributePaths = {"boardTags", "account"})
+    @Query("select b from Board b left join Likes l on b.id = l.board.id where l.account.id = :accountId order by l.createdAt desc")
+    Slice<Board> findAllByAccountLikesWithBoardTagsAndAccount(@Param("accountId") Long accountId, Pageable pageable);
+
     @Modifying(flushAutomatically = true)
     @Query("update Board b set b.views = b.views + 1 where b.id = :boardId")
     void updateViews(@Param("boardId") Long boardId);

--- a/back/src/main/java/travelRepo/domain/board/service/BoardService.java
+++ b/back/src/main/java/travelRepo/domain/board/service/BoardService.java
@@ -17,7 +17,6 @@ import travelRepo.domain.board.repository.BoardRepository;
 import travelRepo.domain.board.repository.BoardTagRepository;
 import travelRepo.domain.board.repository.TagRepository;
 import travelRepo.domain.comment.repository.CommentRepository;
-import travelRepo.domain.likes.entity.Likes;
 import travelRepo.domain.likes.likesRepository.LikesRepository;
 import travelRepo.global.common.dto.IdDto;
 import travelRepo.global.common.dto.SliceDto;
@@ -129,8 +128,7 @@ public class BoardService {
 
     public SliceDto<BoardSummaryRes> findBoardsByLikes(Long accountId, Pageable pageable) {
 
-        Slice<Likes> likes = likesRepository.findAllByAccountIdWithBoard(accountId, pageable);
-        Slice<Board> boards = likes.map(Likes::getBoard);
+        Slice<Board> boards = boardRepository.findAllByAccountLikesWithBoardTagsAndAccount(accountId, pageable);
 
         return new SliceDto<>(boards.map(BoardSummaryRes::of));
     }

--- a/back/src/main/java/travelRepo/domain/likes/likesRepository/LikesRepository.java
+++ b/back/src/main/java/travelRepo/domain/likes/likesRepository/LikesRepository.java
@@ -1,8 +1,5 @@
 package travelRepo.domain.likes.likesRepository;
 
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
-import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -23,10 +20,6 @@ public interface LikesRepository extends JpaRepository<Likes, Long> {
     @Modifying(clearAutomatically = true)
     @Query("delete from Likes likes where likes.board.id = :boardId")
     void deleteByBoardId(@Param("boardId") Long BoardId);
-
-    @EntityGraph(attributePaths = {"board"})
-    @Query("select l from Likes l where l.account.id = :accountId")
-    Slice<Likes> findAllByAccountIdWithBoard(@Param("accountId") Long accountId, Pageable pageable);
 
     boolean existsByAccount_IdAndBoard_Id(Long AccountId, Long BoardId);
 

--- a/back/src/main/resources/static/docs/index.html
+++ b/back/src/main/resources/static/docs/index.html
@@ -465,6 +465,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_게시글_단일_조회">2.4. 게시글 단일 조회</a></li>
 <li><a href="#_게시글_전체_조회">2.5. 게시글 전체 조회</a></li>
 <li><a href="#_유저_게시글_조회">2.6. 유저 게시글 조회</a></li>
+<li><a href="#_좋아요한_게시글_조회">2.7. 좋아요한 게시글 조회</a></li>
 </ul>
 </li>
 <li><a href="#_commentcontroller">3. CommentController</a>
@@ -527,7 +528,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <pre class="prettyprint highlight nowrap"><code data-lang="http">POST /login HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Accept: application/json
-Content-Length: 59
+Content-Length: 62
 Host: localhost:8080
 
 {
@@ -570,7 +571,7 @@ Host: localhost:8080
 Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjkxNzk4MjMsImV4cCI6MTY2OTE4MzQyM30.uZqW2M3Z9qiz-8I3z8GWjouafCIXVU8aUOp7j91fNq4
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjkzNTc1MzQsImV4cCI6MTY2OTM2MTEzNH0.4C7yInc2qfoPqdRgP1DlNE8T34waNrA3G3kpIJxblUU
 X-Content-Type-Options: nosniff
 X-XSS-Protection: 1; mode=block
 Cache-Control: no-cache, no-store, max-age=0, must-revalidate
@@ -712,7 +713,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 14
+Content-Length: 16
 
 {
   "id" : 1
@@ -749,7 +750,7 @@ Content-Length: 14
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/accounts/modify' -i -X POST \
     -H 'Content-Type: application/json;charset=UTF-8' \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjkxNzk4MjMsImV4cCI6MTY2OTE4MzQyM30.uZqW2M3Z9qiz-8I3z8GWjouafCIXVU8aUOp7j91fNq4' \
+    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjkzNTc1MzQsImV4cCI6MTY2OTM2MTEzNH0.4C7yInc2qfoPqdRgP1DlNE8T34waNrA3G3kpIJxblUU' \
     -H 'Accept: application/json' \
     -d '{
   "password" : "123456789",
@@ -764,9 +765,9 @@ Content-Length: 14
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">POST /accounts/modify HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjkxNzk4MjMsImV4cCI6MTY2OTE4MzQyM30.uZqW2M3Z9qiz-8I3z8GWjouafCIXVU8aUOp7j91fNq4
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjkzNTc1MzQsImV4cCI6MTY2OTM2MTEzNH0.4C7yInc2qfoPqdRgP1DlNE8T34waNrA3G3kpIJxblUU
 Accept: application/json
-Content-Length: 125
+Content-Length: 130
 Host: localhost:8080
 
 {
@@ -850,7 +851,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 18
+Content-Length: 20
 
 {
   "id" : 10001
@@ -886,14 +887,14 @@ Content-Length: 18
 <div class="title">curl-request</div>
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/accounts' -i -X DELETE \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjkxNzk4MjMsImV4cCI6MTY2OTE4MzQyM30.uZqW2M3Z9qiz-8I3z8GWjouafCIXVU8aUOp7j91fNq4'</code></pre>
+    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjkzNTc1MzIsImV4cCI6MTY2OTM2MTEzMn0.gxAFAPIUCxQm2G-rWjBbKUvVT76stMMFUREaMZ8B02I'</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">http-request</div>
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">DELETE /accounts HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjkxNzk4MjMsImV4cCI6MTY2OTE4MzQyM30.uZqW2M3Z9qiz-8I3z8GWjouafCIXVU8aUOp7j91fNq4
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjkzNTc1MzIsImV4cCI6MTY2OTM2MTEzMn0.gxAFAPIUCxQm2G-rWjBbKUvVT76stMMFUREaMZ8B02I
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -986,7 +987,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 257
+Content-Length: 265
 
 {
   "id" : 10001,
@@ -1058,14 +1059,14 @@ Content-Length: 257
 <div class="title">curl-request</div>
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/accounts/login' -i -X GET \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjkxNzk4MjMsImV4cCI6MTY2OTE4MzQyM30.uZqW2M3Z9qiz-8I3z8GWjouafCIXVU8aUOp7j91fNq4'</code></pre>
+    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjkzNTc1MzQsImV4cCI6MTY2OTM2MTEzNH0.4C7yInc2qfoPqdRgP1DlNE8T34waNrA3G3kpIJxblUU'</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">http-request</div>
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">GET /accounts/login HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjkxNzk4MjMsImV4cCI6MTY2OTE4MzQyM30.uZqW2M3Z9qiz-8I3z8GWjouafCIXVU8aUOp7j91fNq4
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjkzNTc1MzQsImV4cCI6MTY2OTM2MTEzNH0.4C7yInc2qfoPqdRgP1DlNE8T34waNrA3G3kpIJxblUU
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -1105,7 +1106,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 257
+Content-Length: 265
 
 {
   "id" : 10001,
@@ -1177,14 +1178,14 @@ Content-Length: 257
 <div class="title">curl-request</div>
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/accounts/follow/10001?page=1&amp;size=5&amp;sort=createdAt%2Cdesc&amp;status=following' -i -X GET \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjkxNzk4MjMsImV4cCI6MTY2OTE4MzQyM30.uZqW2M3Z9qiz-8I3z8GWjouafCIXVU8aUOp7j91fNq4'</code></pre>
+    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjkzNTc1MzQsImV4cCI6MTY2OTM2MTEzNH0.4C7yInc2qfoPqdRgP1DlNE8T34waNrA3G3kpIJxblUU'</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">http-request</div>
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">GET /accounts/follow/10001?page=1&amp;size=5&amp;sort=createdAt%2Cdesc&amp;status=following HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjkxNzk4MjMsImV4cCI6MTY2OTE4MzQyM30.uZqW2M3Z9qiz-8I3z8GWjouafCIXVU8aUOp7j91fNq4
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjkzNTc1MzQsImV4cCI6MTY2OTM2MTEzNH0.4C7yInc2qfoPqdRgP1DlNE8T34waNrA3G3kpIJxblUU
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -1283,7 +1284,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 963
+Content-Length: 993
 
 {
   "content" : [ {
@@ -1435,7 +1436,7 @@ Content-Length: 963
 <pre class="prettyprint highlight nowrap"><code data-lang="http">POST /accounts/tempPassword/email HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Accept: application/json
-Content-Length: 32
+Content-Length: 34
 Host: localhost:8080
 
 {
@@ -1494,7 +1495,7 @@ X-Frame-Options: DENY</code></pre>
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/boards' -i -X POST \
     -H 'Content-Type: application/json;charset=UTF-8' \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InVzZXJBQHRlc3QuY29tIiwic3ViIjoiMjAwMDEiLCJpYXQiOjE2NjkxNzk4MjQsImV4cCI6MTY2OTE4MzQyNH0.b5EPE5sSpq01Q2z2DN3dBJ2bLQOaWbmKjlUl7_Q4wVs' \
+    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InVzZXJBQHRlc3QuY29tIiwic3ViIjoiMjAwMDEiLCJpYXQiOjE2NjkzNTc1MzUsImV4cCI6MTY2OTM2MTEzNX0.C6JL30RTrcW6GNEBhG6hluQjTxh735J-T4TCOf19su8' \
     -H 'Accept: application/json' \
     -d '{
   "title" : "board title",
@@ -1511,9 +1512,9 @@ X-Frame-Options: DENY</code></pre>
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">POST /boards HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InVzZXJBQHRlc3QuY29tIiwic3ViIjoiMjAwMDEiLCJpYXQiOjE2NjkxNzk4MjQsImV4cCI6MTY2OTE4MzQyNH0.b5EPE5sSpq01Q2z2DN3dBJ2bLQOaWbmKjlUl7_Q4wVs
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InVzZXJBQHRlc3QuY29tIiwic3ViIjoiMjAwMDEiLCJpYXQiOjE2NjkzNTc1MzUsImV4cCI6MTY2OTM2MTEzNX0.C6JL30RTrcW6GNEBhG6hluQjTxh735J-T4TCOf19su8
 Accept: application/json
-Content-Length: 273
+Content-Length: 280
 Host: localhost:8080
 
 {
@@ -1609,7 +1610,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 14
+Content-Length: 16
 
 {
   "id" : 3
@@ -1646,7 +1647,7 @@ Content-Length: 14
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/boards/31001' -i -X POST \
     -H 'Content-Type: application/json;charset=UTF-8' \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InVzZXJBQHRlc3QuY29tIiwic3ViIjoiMjAwMDEiLCJpYXQiOjE2NjkxNzk4MjQsImV4cCI6MTY2OTE4MzQyNH0.b5EPE5sSpq01Q2z2DN3dBJ2bLQOaWbmKjlUl7_Q4wVs' \
+    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InVzZXJBQHRlc3QuY29tIiwic3ViIjoiMjAwMDEiLCJpYXQiOjE2NjkzNTc1MzYsImV4cCI6MTY2OTM2MTEzNn0.nhBH3oeoTLmLN3OYPskiJh1WCgG5wGUyDKeCFQRUXi0' \
     -H 'Accept: application/json' \
     -d '{
   "title" : "modified board title",
@@ -1663,9 +1664,9 @@ Content-Length: 14
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">POST /boards/31001 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InVzZXJBQHRlc3QuY29tIiwic3ViIjoiMjAwMDEiLCJpYXQiOjE2NjkxNzk4MjQsImV4cCI6MTY2OTE4MzQyNH0.b5EPE5sSpq01Q2z2DN3dBJ2bLQOaWbmKjlUl7_Q4wVs
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InVzZXJBQHRlc3QuY29tIiwic3ViIjoiMjAwMDEiLCJpYXQiOjE2NjkzNTc1MzYsImV4cCI6MTY2OTM2MTEzNn0.nhBH3oeoTLmLN3OYPskiJh1WCgG5wGUyDKeCFQRUXi0
 Accept: application/json
-Content-Length: 306
+Content-Length: 313
 Host: localhost:8080
 
 {
@@ -1783,7 +1784,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 18
+Content-Length: 20
 
 {
   "id" : 31001
@@ -1819,14 +1820,14 @@ Content-Length: 18
 <div class="title">curl-request</div>
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/boards/31002' -i -X DELETE \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InVzZXJBQHRlc3QuY29tIiwic3ViIjoiMjAwMDEiLCJpYXQiOjE2NjkxNzk4MjQsImV4cCI6MTY2OTE4MzQyNH0.b5EPE5sSpq01Q2z2DN3dBJ2bLQOaWbmKjlUl7_Q4wVs'</code></pre>
+    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InVzZXJBQHRlc3QuY29tIiwic3ViIjoiMjAwMDEiLCJpYXQiOjE2NjkzNTc1MzUsImV4cCI6MTY2OTM2MTEzNX0.C6JL30RTrcW6GNEBhG6hluQjTxh735J-T4TCOf19su8'</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">http-request</div>
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">DELETE /boards/31002 HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InVzZXJBQHRlc3QuY29tIiwic3ViIjoiMjAwMDEiLCJpYXQiOjE2NjkxNzk4MjQsImV4cCI6MTY2OTE4MzQyNH0.b5EPE5sSpq01Q2z2DN3dBJ2bLQOaWbmKjlUl7_Q4wVs
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InVzZXJBQHRlc3QuY29tIiwic3ViIjoiMjAwMDEiLCJpYXQiOjE2NjkzNTc1MzUsImV4cCI6MTY2OTM2MTEzNX0.C6JL30RTrcW6GNEBhG6hluQjTxh735J-T4TCOf19su8
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -1943,7 +1944,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 551
+Content-Length: 567
 
 {
   "boardId" : 21001,
@@ -2125,7 +2126,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 8553
+Content-Length: 8779
 
 {
   "content" : [ {
@@ -2497,7 +2498,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 3079
+Content-Length: 3162
 
 {
   "content" : [ {
@@ -2672,6 +2673,235 @@ Content-Length: 3079
 </tr>
 </tbody>
 </table>
+</div>
+<div class="sect2">
+<h3 id="_좋아요한_게시글_조회">2.7. 좋아요한 게시글 조회</h3>
+<div class="listingblock">
+<div class="title">curl-request</div>
+<div class="content">
+<pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/boards/like/account/20001' -i -X GET \
+    -H 'Accept: application/json'</code></pre>
+</div>
+</div>
+<div class="listingblock">
+<div class="title">http-request</div>
+<div class="content">
+<pre class="prettyprint highlight nowrap"><code data-lang="http">GET /boards/like/account/20001 HTTP/1.1
+Accept: application/json
+Host: localhost:8080</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 33. /boards/like/account/{accountId}</caption>
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+<th class="tableblock halign-left valign-top">Required</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>accountId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">계정 식별자</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code><strong>true</strong></code></p></td>
+</tr>
+</tbody>
+</table>
+<div class="listingblock">
+<div class="title">http-response</div>
+<div class="content">
+<pre class="prettyprint highlight nowrap"><code data-lang="http">HTTP/1.1 200 OK
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json;charset=UTF-8
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 1; mode=block
+Cache-Control: no-cache, no-store, max-age=0, must-revalidate
+Pragma: no-cache
+Expires: 0
+X-Frame-Options: DENY
+Content-Length: 3144
+
+{
+  "content" : [ {
+    "boardId" : 21019,
+    "thumbnail" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
+    "title" : "testTitle",
+    "likeCount" : 9,
+    "tags" : [ ],
+    "account" : {
+      "accountId" : 20001,
+      "profile" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
+      "nickname" : "userA"
+    }
+  }, {
+    "boardId" : 21016,
+    "thumbnail" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
+    "title" : "testTitleContainsQuery",
+    "likeCount" : 6,
+    "tags" : [ ],
+    "account" : {
+      "accountId" : 20001,
+      "profile" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
+      "nickname" : "userA"
+    }
+  }, {
+    "boardId" : 21013,
+    "thumbnail" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
+    "title" : "testTitle",
+    "likeCount" : 3,
+    "tags" : [ ],
+    "account" : {
+      "accountId" : 20001,
+      "profile" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
+      "nickname" : "userA"
+    }
+  }, {
+    "boardId" : 21010,
+    "thumbnail" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
+    "title" : "testTitleContainsQuery",
+    "likeCount" : 0,
+    "tags" : [ "testContainsQuery" ],
+    "account" : {
+      "accountId" : 20001,
+      "profile" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
+      "nickname" : "userA"
+    }
+  }, {
+    "boardId" : 21007,
+    "thumbnail" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
+    "title" : "testTitle",
+    "likeCount" : 7,
+    "tags" : [ ],
+    "account" : {
+      "accountId" : 20001,
+      "profile" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
+      "nickname" : "userA"
+    }
+  }, {
+    "boardId" : 21004,
+    "thumbnail" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
+    "title" : "testTitleContainsQuery",
+    "likeCount" : 4,
+    "tags" : [ ],
+    "account" : {
+      "accountId" : 20001,
+      "profile" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
+      "nickname" : "userA"
+    }
+  }, {
+    "boardId" : 21001,
+    "thumbnail" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
+    "title" : "testTitle",
+    "likeCount" : 1,
+    "tags" : [ "tag1", "tag2" ],
+    "account" : {
+      "accountId" : 20001,
+      "profile" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
+      "nickname" : "userA"
+    }
+  } ],
+  "sliceNumber" : 1,
+  "size" : 20,
+  "hasNext" : false,
+  "numberOfElements" : 7
+}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 34. response-fields</caption>
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[]</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">게시물 목록</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].boardId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">게시글 식별자</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].thumbnail</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">게시글 썸네일</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].title</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">게시글 제목</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].likeCount</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">게시글 좋아요 수</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].tags</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">게시글 태그</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].account</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">글쓴이</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].account.accountId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">계정 식별자</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].account.profile</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">프로필 사진</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].account.nickname</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">닉네임</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>sliceNumber</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">현재 슬라이스 번호</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>size</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">슬라이스 사이즈</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>hasNext</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">다음 슬라이스 존재 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>numberOfElements</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">현재 슬라이스의 게시글 수</p></td>
+</tr>
+</tbody>
+</table>
 <hr>
 </div>
 </div>
@@ -2686,7 +2916,7 @@ Content-Length: 3079
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/comments' -i -X POST \
     -H 'Content-Type: application/json;charset=UTF-8' \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InVzZXJBQHRlc3QuY29tIiwic3ViIjoiMjAwMDEiLCJpYXQiOjE2NjkxNzk4MjQsImV4cCI6MTY2OTE4MzQyNH0.b5EPE5sSpq01Q2z2DN3dBJ2bLQOaWbmKjlUl7_Q4wVs' \
+    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InVzZXJBQHRlc3QuY29tIiwic3ViIjoiMjAwMDEiLCJpYXQiOjE2NjkzNTc1MzYsImV4cCI6MTY2OTM2MTEzNn0.nhBH3oeoTLmLN3OYPskiJh1WCgG5wGUyDKeCFQRUXi0' \
     -d '{
   "boardId" : 21001,
   "content" : "testCommentContents"
@@ -2698,8 +2928,8 @@ Content-Length: 3079
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">POST /comments HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InVzZXJBQHRlc3QuY29tIiwic3ViIjoiMjAwMDEiLCJpYXQiOjE2NjkxNzk4MjQsImV4cCI6MTY2OTE4MzQyNH0.b5EPE5sSpq01Q2z2DN3dBJ2bLQOaWbmKjlUl7_Q4wVs
-Content-Length: 60
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InVzZXJBQHRlc3QuY29tIiwic3ViIjoiMjAwMDEiLCJpYXQiOjE2NjkzNTc1MzYsImV4cCI6MTY2OTM2MTEzNn0.nhBH3oeoTLmLN3OYPskiJh1WCgG5wGUyDKeCFQRUXi0
+Content-Length: 63
 Host: localhost:8080
 
 {
@@ -2709,7 +2939,7 @@ Host: localhost:8080
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 33. request-fields</caption>
+<caption class="title">Table 35. request-fields</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -2736,7 +2966,7 @@ Host: localhost:8080
 </tbody>
 </table>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 34. request-headers</caption>
+<caption class="title">Table 36. request-headers</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -2780,7 +3010,7 @@ X-Frame-Options: DENY</code></pre>
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/comments/25001' -i -X PATCH \
     -H 'Content-Type: application/json;charset=UTF-8' \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InVzZXJBQHRlc3QuY29tIiwic3ViIjoiMjAwMDEiLCJpYXQiOjE2NjkxNzk4MjQsImV4cCI6MTY2OTE4MzQyNH0.b5EPE5sSpq01Q2z2DN3dBJ2bLQOaWbmKjlUl7_Q4wVs' \
+    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InVzZXJBQHRlc3QuY29tIiwic3ViIjoiMjAwMDEiLCJpYXQiOjE2NjkzNTc1MzYsImV4cCI6MTY2OTM2MTEzNn0.nhBH3oeoTLmLN3OYPskiJh1WCgG5wGUyDKeCFQRUXi0' \
     -d '{
   "content" : "modified testContents"
 }'</code></pre>
@@ -2791,8 +3021,8 @@ X-Frame-Options: DENY</code></pre>
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">PATCH /comments/25001 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InVzZXJBQHRlc3QuY29tIiwic3ViIjoiMjAwMDEiLCJpYXQiOjE2NjkxNzk4MjQsImV4cCI6MTY2OTE4MzQyNH0.b5EPE5sSpq01Q2z2DN3dBJ2bLQOaWbmKjlUl7_Q4wVs
-Content-Length: 41
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InVzZXJBQHRlc3QuY29tIiwic3ViIjoiMjAwMDEiLCJpYXQiOjE2NjkzNTc1MzYsImV4cCI6MTY2OTM2MTEzNn0.nhBH3oeoTLmLN3OYPskiJh1WCgG5wGUyDKeCFQRUXi0
+Content-Length: 43
 Host: localhost:8080
 
 {
@@ -2801,7 +3031,7 @@ Host: localhost:8080
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 35. /comments/{commentId}</caption>
+<caption class="title">Table 37. /comments/{commentId}</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -2823,7 +3053,7 @@ Host: localhost:8080
 </tbody>
 </table>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 36. request-fields</caption>
+<caption class="title">Table 38. request-fields</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -2845,7 +3075,7 @@ Host: localhost:8080
 </tbody>
 </table>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 37. request-headers</caption>
+<caption class="title">Table 39. request-headers</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -2888,19 +3118,19 @@ X-Frame-Options: DENY</code></pre>
 <div class="title">curl-request</div>
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/comments/35001' -i -X DELETE \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InVzZXJBQHRlc3QuY29tIiwic3ViIjoiMjAwMDEiLCJpYXQiOjE2NjkxNzk4MjQsImV4cCI6MTY2OTE4MzQyNH0.b5EPE5sSpq01Q2z2DN3dBJ2bLQOaWbmKjlUl7_Q4wVs'</code></pre>
+    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InVzZXJBQHRlc3QuY29tIiwic3ViIjoiMjAwMDEiLCJpYXQiOjE2NjkzNTc1MzYsImV4cCI6MTY2OTM2MTEzNn0.nhBH3oeoTLmLN3OYPskiJh1WCgG5wGUyDKeCFQRUXi0'</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">http-request</div>
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">DELETE /comments/35001 HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InVzZXJBQHRlc3QuY29tIiwic3ViIjoiMjAwMDEiLCJpYXQiOjE2NjkxNzk4MjQsImV4cCI6MTY2OTE4MzQyNH0.b5EPE5sSpq01Q2z2DN3dBJ2bLQOaWbmKjlUl7_Q4wVs
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InVzZXJBQHRlc3QuY29tIiwic3ViIjoiMjAwMDEiLCJpYXQiOjE2NjkzNTc1MzYsImV4cCI6MTY2OTM2MTEzNn0.nhBH3oeoTLmLN3OYPskiJh1WCgG5wGUyDKeCFQRUXi0
 Host: localhost:8080</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 38. /comments/{commentId}</caption>
+<caption class="title">Table 40. /comments/{commentId}</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -2922,7 +3152,7 @@ Host: localhost:8080</code></pre>
 </tbody>
 </table>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 39. request-headers</caption>
+<caption class="title">Table 41. request-headers</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -2977,7 +3207,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 40. /comments/board/{boardId}</caption>
+<caption class="title">Table 42. /comments/board/{boardId}</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -2999,7 +3229,7 @@ Host: localhost:8080</code></pre>
 </tbody>
 </table>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 41. request-parameters</caption>
+<caption class="title">Table 43. request-parameters</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -3039,26 +3269,17 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 1606
+Content-Length: 1657
 
 {
   "content" : [ {
-    "commentId" : 25004,
+    "commentId" : 25003,
     "content" : "testComment",
     "createdAt" : "2022-10-14T14:00:01",
     "account" : {
-      "accountId" : 20001,
+      "accountId" : 20003,
       "profile" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
-      "nickname" : "userA"
-    }
-  }, {
-    "commentId" : 25005,
-    "content" : "testComment",
-    "createdAt" : "2022-10-14T14:00:01",
-    "account" : {
-      "accountId" : 20002,
-      "profile" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
-      "nickname" : "userB"
+      "nickname" : "userC"
     }
   }, {
     "commentId" : 25006,
@@ -3070,22 +3291,31 @@ Content-Length: 1606
       "nickname" : "userC"
     }
   }, {
-    "commentId" : 25003,
-    "content" : "testComment",
-    "createdAt" : "2022-10-14T14:00:01",
-    "account" : {
-      "accountId" : 20003,
-      "profile" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
-      "nickname" : "userC"
-    }
-  }, {
-    "commentId" : 25002,
+    "commentId" : 25005,
     "content" : "testComment",
     "createdAt" : "2022-10-14T14:00:01",
     "account" : {
       "accountId" : 20002,
       "profile" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
       "nickname" : "userB"
+    }
+  }, {
+    "commentId" : 25001,
+    "content" : "testComment",
+    "createdAt" : "2022-10-14T14:00:01",
+    "account" : {
+      "accountId" : 20001,
+      "profile" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
+      "nickname" : "userA"
+    }
+  }, {
+    "commentId" : 25004,
+    "content" : "testComment",
+    "createdAt" : "2022-10-14T14:00:01",
+    "account" : {
+      "accountId" : 20001,
+      "profile" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
+      "nickname" : "userA"
     }
   } ],
   "sliceNumber" : 1,
@@ -3096,7 +3326,7 @@ Content-Length: 1606
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 42. response-fields</caption>
+<caption class="title">Table 44. response-fields</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -3185,19 +3415,19 @@ Content-Length: 1606
 <div class="title">curl-request</div>
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/follows/10002' -i -X POST \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjkxNzk4MjQsImV4cCI6MTY2OTE4MzQyNH0.LwqG6_CSrOd9quG7XAuLVDtFzzUeYQAB0JEyn00EE7Y'</code></pre>
+    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjkzNTc1MzYsImV4cCI6MTY2OTM2MTEzNn0.fWLnA3dfqJL0dS67Rmq5EzI7Zhc06Ft8kJ86iw3SDLM'</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">http-request</div>
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">POST /follows/10002 HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjkxNzk4MjQsImV4cCI6MTY2OTE4MzQyNH0.LwqG6_CSrOd9quG7XAuLVDtFzzUeYQAB0JEyn00EE7Y
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjkzNTc1MzYsImV4cCI6MTY2OTM2MTEzNn0.fWLnA3dfqJL0dS67Rmq5EzI7Zhc06Ft8kJ86iw3SDLM
 Host: localhost:8080</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 43. request-headers</caption>
+<caption class="title">Table 45. request-headers</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -3219,7 +3449,7 @@ Host: localhost:8080</code></pre>
 </tbody>
 </table>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 44. /follows/{accountId}</caption>
+<caption class="title">Table 46. /follows/{accountId}</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -3254,7 +3484,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 26
+Content-Length: 28
 
 {
   "status" : "SUCCESS"
@@ -3262,7 +3492,7 @@ Content-Length: 26
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 45. response-fields</caption>
+<caption class="title">Table 47. response-fields</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -3290,19 +3520,19 @@ Content-Length: 26
 <div class="title">curl-request</div>
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/follows/10002' -i -X GET \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjkxNzk4MjQsImV4cCI6MTY2OTE4MzQyNH0.LwqG6_CSrOd9quG7XAuLVDtFzzUeYQAB0JEyn00EE7Y'</code></pre>
+    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjkzNTc1MzYsImV4cCI6MTY2OTM2MTEzNn0.fWLnA3dfqJL0dS67Rmq5EzI7Zhc06Ft8kJ86iw3SDLM'</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">http-request</div>
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">GET /follows/10002 HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjkxNzk4MjQsImV4cCI6MTY2OTE4MzQyNH0.LwqG6_CSrOd9quG7XAuLVDtFzzUeYQAB0JEyn00EE7Y
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjkzNTc1MzYsImV4cCI6MTY2OTM2MTEzNn0.fWLnA3dfqJL0dS67Rmq5EzI7Zhc06Ft8kJ86iw3SDLM
 Host: localhost:8080</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 46. request-headers</caption>
+<caption class="title">Table 48. request-headers</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -3324,7 +3554,7 @@ Host: localhost:8080</code></pre>
 </tbody>
 </table>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 47. /follows/{accountId}</caption>
+<caption class="title">Table 49. /follows/{accountId}</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -3359,7 +3589,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 21
+Content-Length: 23
 
 {
   "follow" : true
@@ -3367,7 +3597,7 @@ Content-Length: 21
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 48. response-fields</caption>
+<caption class="title">Table 50. response-fields</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -3401,19 +3631,19 @@ Content-Length: 21
 <div class="title">curl-request</div>
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/likes/12002' -i -X POST \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjkxNzk4MjQsImV4cCI6MTY2OTE4MzQyNH0.LwqG6_CSrOd9quG7XAuLVDtFzzUeYQAB0JEyn00EE7Y'</code></pre>
+    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjkzNTc1MzYsImV4cCI6MTY2OTM2MTEzNn0.fWLnA3dfqJL0dS67Rmq5EzI7Zhc06Ft8kJ86iw3SDLM'</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">http-request</div>
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">POST /likes/12002 HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjkxNzk4MjQsImV4cCI6MTY2OTE4MzQyNH0.LwqG6_CSrOd9quG7XAuLVDtFzzUeYQAB0JEyn00EE7Y
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjkzNTc1MzYsImV4cCI6MTY2OTM2MTEzNn0.fWLnA3dfqJL0dS67Rmq5EzI7Zhc06Ft8kJ86iw3SDLM
 Host: localhost:8080</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 49. request-headers</caption>
+<caption class="title">Table 51. request-headers</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -3435,7 +3665,7 @@ Host: localhost:8080</code></pre>
 </tbody>
 </table>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 50. /likes/{boardId}</caption>
+<caption class="title">Table 52. /likes/{boardId}</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -3470,7 +3700,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 26
+Content-Length: 28
 
 {
   "status" : "SUCCESS"
@@ -3478,7 +3708,7 @@ Content-Length: 26
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 51. response-fields</caption>
+<caption class="title">Table 53. response-fields</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -3506,19 +3736,19 @@ Content-Length: 26
 <div class="title">curl-request</div>
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/likes/12002' -i -X GET \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjkxNzk4MjQsImV4cCI6MTY2OTE4MzQyNH0.LwqG6_CSrOd9quG7XAuLVDtFzzUeYQAB0JEyn00EE7Y'</code></pre>
+    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjkzNTc1MzYsImV4cCI6MTY2OTM2MTEzNn0.fWLnA3dfqJL0dS67Rmq5EzI7Zhc06Ft8kJ86iw3SDLM'</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">http-request</div>
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">GET /likes/12002 HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjkxNzk4MjQsImV4cCI6MTY2OTE4MzQyNH0.LwqG6_CSrOd9quG7XAuLVDtFzzUeYQAB0JEyn00EE7Y
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjkzNTc1MzYsImV4cCI6MTY2OTM2MTEzNn0.fWLnA3dfqJL0dS67Rmq5EzI7Zhc06Ft8kJ86iw3SDLM
 Host: localhost:8080</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 52. request-headers</caption>
+<caption class="title">Table 54. request-headers</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -3540,7 +3770,7 @@ Host: localhost:8080</code></pre>
 </tbody>
 </table>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 53. /likes/{boardId}</caption>
+<caption class="title">Table 55. /likes/{boardId}</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -3575,7 +3805,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 20
+Content-Length: 22
 
 {
   "likes" : true
@@ -3583,7 +3813,7 @@ Content-Length: 20
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 54. response-fields</caption>
+<caption class="title">Table 56. response-fields</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -3618,7 +3848,7 @@ Content-Length: 20
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/image-files' -i -X POST \
     -H 'Content-Type: multipart/form-data;charset=UTF-8' \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjkxNzk4MjQsImV4cCI6MTY2OTE4MzQyNH0.LwqG6_CSrOd9quG7XAuLVDtFzzUeYQAB0JEyn00EE7Y' \
+    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjkzNTc1MzYsImV4cCI6MTY2OTM2MTEzNn0.fWLnA3dfqJL0dS67Rmq5EzI7Zhc06Ft8kJ86iw3SDLM' \
     -F 'images=@image1.jpeg;type=image/jpeg' \
     -F 'images=@image2.jpeg;type=image/jpeg' \
     -F 'images=@image3.jpeg;type=image/jpeg'</code></pre>
@@ -3629,7 +3859,7 @@ Content-Length: 20
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">POST /image-files HTTP/1.1
 Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjkxNzk4MjQsImV4cCI6MTY2OTE4MzQyNH0.LwqG6_CSrOd9quG7XAuLVDtFzzUeYQAB0JEyn00EE7Y
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjkzNTc1MzYsImV4cCI6MTY2OTM2MTEzNn0.fWLnA3dfqJL0dS67Rmq5EzI7Zhc06Ft8kJ86iw3SDLM
 Host: localhost:8080
 
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
@@ -3651,7 +3881,7 @@ Content-Type: image/jpeg
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 55. request-headers</caption>
+<caption class="title">Table 57. request-headers</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -3673,7 +3903,7 @@ Content-Type: image/jpeg
 </tbody>
 </table>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 56. request-parts</caption>
+<caption class="title">Table 58. request-parts</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -3708,15 +3938,15 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 260
+Content-Length: 262
 
 {
-  "imagePaths" : [ "http://localhost:8080/image-files/1486b93c-2538-4b53-af84-2e7d4481d27d.jpeg", "http://localhost:8080/image-files/eea0a6df-7903-4f21-bb02-bbd7a737d2c0.jpeg", "http://localhost:8080/image-files/efed2978-8fe4-47c5-ba5b-05bead67620d.jpeg" ]
+  "imagePaths" : [ "http://localhost:8080/image-files/c1ccc120-7941-4c3b-b553-2b13272b8a5a.jpeg", "http://localhost:8080/image-files/90f7c05c-dd3b-4944-bcc7-2d132a479e0e.jpeg", "http://localhost:8080/image-files/71729b51-16f8-4ab8-9351-834992a2bd7c.jpeg" ]
 }</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 57. response-fields</caption>
+<caption class="title">Table 59. response-fields</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -3744,7 +3974,7 @@ Content-Length: 260
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2022-11-22 15:50:27 +0900
+Last updated 2022-11-25 15:25:15 +0900
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prettify/r298/prettify.min.css">

--- a/back/src/test/java/travelRepo/domain/board/controller/BoardControllerTest.java
+++ b/back/src/test/java/travelRepo/domain/board/controller/BoardControllerTest.java
@@ -582,8 +582,60 @@ class BoardControllerTest extends After {
         //then
         actions
                 .andExpect(status().isOk())
+                .andExpect(jsonPath("$.sliceNumber").value(1))
+                .andExpect(jsonPath("$.size").value(20))
+                .andExpect(jsonPath("$.hasNext").value(false))
+                .andExpect(jsonPath("$.numberOfElements").value(7))
                 .andDo(document(
                         "accountBoardList",
+                        getRequestPreProcessor(),
+                        getResponsePreProcessor(),
+                        pathParameters(
+                                parameterWithName("accountId").description("계정 식별자")
+                        ),
+                        responseFields(
+                                List.of(
+                                        fieldWithPath("content[]").type(JsonFieldType.ARRAY).description("게시물 목록"),
+                                        fieldWithPath("content[].boardId").type(JsonFieldType.NUMBER).description("게시글 식별자"),
+                                        fieldWithPath("content[].thumbnail").type(JsonFieldType.STRING).description("게시글 썸네일"),
+                                        fieldWithPath("content[].title").type(JsonFieldType.STRING).description("게시글 제목"),
+                                        fieldWithPath("content[].likeCount").type(JsonFieldType.NUMBER).description("게시글 좋아요 수"),
+                                        fieldWithPath("content[].tags").type(JsonFieldType.ARRAY).description("게시글 태그"),
+                                        fieldWithPath("content[].account").type(JsonFieldType.OBJECT).description("글쓴이"),
+                                        fieldWithPath("content[].account.accountId").type(JsonFieldType.NUMBER).description("계정 식별자"),
+                                        fieldWithPath("content[].account.profile").type(JsonFieldType.STRING).description("프로필 사진"),
+                                        fieldWithPath("content[].account.nickname").type(JsonFieldType.STRING).description("닉네임"),
+                                        fieldWithPath("sliceNumber").type(JsonFieldType.NUMBER).description("현재 슬라이스 번호"),
+                                        fieldWithPath("size").type(JsonFieldType.NUMBER).description("슬라이스 사이즈"),
+                                        fieldWithPath("hasNext").type(JsonFieldType.BOOLEAN).description("다음 슬라이스 존재 여부"),
+                                        fieldWithPath("numberOfElements").type(JsonFieldType.NUMBER).description("현재 슬라이스의 게시글 수")
+                                )
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("좋아요한 게시글 조회_성공")
+    public void likeBoardList_Success() throws Exception {
+
+        //given
+        Long accountId = 20001L;
+
+        //when
+        ResultActions actions = mockMvc.perform(
+                get("/boards/like/account/{accountId}", accountId)
+                        .accept(MediaType.APPLICATION_JSON)
+        );
+
+        //then
+        actions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.sliceNumber").value(1))
+                .andExpect(jsonPath("$.size").value(20))
+                .andExpect(jsonPath("$.hasNext").value(false))
+                .andExpect(jsonPath("$.numberOfElements").value(7))
+                .andDo(document(
+                        "likeBoardList",
                         getRequestPreProcessor(),
                         getResponsePreProcessor(),
                         pathParameters(

--- a/back/src/test/resources/static/db/data.sql
+++ b/back/src/test/resources/static/db/data.sql
@@ -110,3 +110,11 @@ INSERT INTO Comment(comment_id, createdAt, modifiedAt, content, account_id, boar
 INSERT INTO Comment(comment_id, createdAt, modifiedAt, content, account_id, board_id) VALUES('25006', '2022-10-14 14:00:01', '2022-10-14 14:00:01', 'testComment', '20003', '21001');
 -- for delete
 INSERT INTO Comment(comment_id, createdAt, modifiedAt, content, account_id, board_id) VALUES('35001', '2022-10-14 14:00:01', '2022-10-14 14:00:01', 'testComment', '20001', '31001');
+
+INSERT INTO Likes(likes_id, createdAt, modifiedAt, account_id, board_id) VALUES('26001', '2022-11-14 13:00:01', '2022-11-14 13:00:01', '20001', '21001');
+INSERT INTO Likes(likes_id, createdAt, modifiedAt, account_id, board_id) VALUES('26002', '2022-11-14 13:00:02', '2022-11-14 13:00:02', '20001', '21004');
+INSERT INTO Likes(likes_id, createdAt, modifiedAt, account_id, board_id) VALUES('26003', '2022-11-14 13:00:03', '2022-11-14 13:00:03', '20001', '21007');
+INSERT INTO Likes(likes_id, createdAt, modifiedAt, account_id, board_id) VALUES('26004', '2022-11-14 13:00:04', '2022-11-14 13:00:04', '20001', '21010');
+INSERT INTO Likes(likes_id, createdAt, modifiedAt, account_id, board_id) VALUES('26005', '2022-11-14 13:00:05', '2022-11-14 13:00:05', '20001', '21013');
+INSERT INTO Likes(likes_id, createdAt, modifiedAt, account_id, board_id) VALUES('26006', '2022-11-14 13:00:06', '2022-11-14 13:00:06', '20001', '21016');
+INSERT INTO Likes(likes_id, createdAt, modifiedAt, account_id, board_id) VALUES('26007', '2022-11-14 13:00:07', '2022-11-14 13:00:07', '20001', '21019');


### PR DESCRIPTION
1. 좋아요한 게시글을 조회하는 방법을 기존 LikeRepository에서 조회하는 방법에서 BoardRepository에서 outer join을 통해 조회하는 방법으로 수정했습니다.
 - page, size는 파라미터로 받을 수 있지만 정렬은 최근 좋아요를 누른 순으로 고정했습니다.

2. 좋아요한 게시글 조회 API를 테스트하고 명세서에 추가했습니다.