### PR TITLE
[Fix] 메인페이지 lazy 삭제 및 로딩스피너 통일

### DIFF
--- a/front/src/App.js
+++ b/front/src/App.js
@@ -17,8 +17,8 @@ import MyPost from './pages/myPages/MyPost';
 import MyLikes from './pages/myPages/MyLikes';
 import MyFollower from './pages/myPages/MyFollower';
 import MyFollowing from './pages/myPages/MyFollowing';
+import MainPage from './pages/mainPages/MainPage';
 
-const MainPage = React.lazy(() => import('./pages/mainPages/MainPage'));
 const PublishPage = React.lazy(() => import('./pages/PublishPage'));
 const PostDetailPage = React.lazy(() => import('./pages/PostDetailPage'));
 

--- a/front/src/component/common/Loading.jsx
+++ b/front/src/component/common/Loading.jsx
@@ -1,19 +1,21 @@
 import styled from 'styled-components';
+import LoadingSpinner from './LoadingSpinner';
 
 const LoadingImg = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-  height: calc(100vh - 140px);
+  width: 100vw;
+  height: 100vh;
+  position: absolute;
+  top: 0;
+  left: 0;
 `;
 
 function Loading() {
   return (
     <LoadingImg>
-      <img
-        src="https://upload.wikimedia.org/wikipedia/commons/b/b1/Loading_icon.gif?20151024034921"
-        alt="loading"
-      />
+      <LoadingSpinner width={100} />
     </LoadingImg>
   );
 }

--- a/front/src/component/common/LoadingSpinner.jsx
+++ b/front/src/component/common/LoadingSpinner.jsx
@@ -1,7 +1,12 @@
 import { RotatingLines } from 'react-loader-spinner';
 
-function LoadingSpinner() {
-  return <RotatingLines strokeColor="var(--holder-base-color)" width="60" />;
+function LoadingSpinner({ width }) {
+  return (
+    <RotatingLines
+      strokeColor="var(--holder-base-color)"
+      width={width || '60'}
+    />
+  );
 }
 
 export default LoadingSpinner;


### PR DESCRIPTION
- [x] `Suspense`가 보여주는 로딩스피너와 각 테마페이지에서 보여주는 로딩스피너가 중복되어 메인페이지의 `lazy`를 삭제하였습니다.
- [x] 로딩스피너 통일