### PR TITLE
[Feat] 정렬기능 추가

### DIFF
--- a/front/src/component/main/MainSort.jsx
+++ b/front/src/component/main/MainSort.jsx
@@ -46,14 +46,16 @@ const MainSortBar = styled.div`
   }
 `;
 
-function MainSort({ sortHandler }) {
+function MainSort({ sort, sortHandler }) {
   return (
     <MainSortBar>
       <ul className="main__sortbar">
         <li>
           <button
             onClick={() => {
-              sortHandler('createdAt,desc');
+              if (sort !== 'createdAt,desc') {
+                sortHandler('createdAt,desc');
+              }
             }}
           >
             최신글
@@ -62,7 +64,9 @@ function MainSort({ sortHandler }) {
         <li>
           <button
             onClick={() => {
-              sortHandler('likeCount,desc');
+              if (sort !== 'likeCount,desc') {
+                sortHandler('likeCount,desc');
+              }
             }}
           >
             추천수
@@ -71,7 +75,9 @@ function MainSort({ sortHandler }) {
         <li>
           <button
             onClick={() => {
-              sortHandler('views,desc');
+              if (sort !== 'views,desc') {
+                sortHandler('views,desc');
+              }
             }}
           >
             조회수

--- a/front/src/component/main/MainSort.jsx
+++ b/front/src/component/main/MainSort.jsx
@@ -46,18 +46,36 @@ const MainSortBar = styled.div`
   }
 `;
 
-function MainSort() {
+function MainSort({ sortHandler }) {
   return (
     <MainSortBar>
       <ul className="main__sortbar">
         <li>
-          <button>최신글</button>
+          <button
+            onClick={() => {
+              sortHandler('createdAt,desc');
+            }}
+          >
+            최신글
+          </button>
         </li>
         <li>
-          <button>추천수</button>
+          <button
+            onClick={() => {
+              sortHandler('likeCount,desc');
+            }}
+          >
+            추천수
+          </button>
         </li>
         <li>
-          <button>조회수</button>
+          <button
+            onClick={() => {
+              sortHandler('views,desc');
+            }}
+          >
+            조회수
+          </button>
         </li>
       </ul>
     </MainSortBar>

--- a/front/src/component/publish/PublishForm.jsx
+++ b/front/src/component/publish/PublishForm.jsx
@@ -80,6 +80,10 @@ function PublishForm() {
 
   // 상세 페이지에서 수정 클릭시 정보 받아오기
   useEffect(() => {
+    // 게시글 수정에서 게시글 작성 클릭시 리로딩 되는 분기점
+    if (boardId && isPublishPage) {
+      window.location.reload();
+    }
     if (!isPublishPage) {
       const data = loc.post;
       setFormData({
@@ -94,9 +98,6 @@ function PublishForm() {
       setBoardId(data.boardId);
       ref.current.preview([...data.photos]); // 장착시 미리보기 실행 코드
     }
-    return () => {
-      window.location.reload();
-    };
   }, [loc]);
 
   const mandatory =

--- a/front/src/hooks/useIntersect.js
+++ b/front/src/hooks/useIntersect.js
@@ -8,7 +8,14 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 // setPosts: 받아온 데이터를 state값으로 바꿔줄 setState함수
 // setIsPending: pending state를 바꿔줄 setState함수
 // threshold(default는 0): 지정한 root(default는 뷰포트)에 target이 얼마나 보이는지 비율(0~1)
-const useIntersect = (api, size, setPosts, setIsPending, threshold = 0) => {
+const useIntersect = (
+  api,
+  size,
+  setPosts,
+  setIsPending,
+  threshold = 0,
+  sort = 'createdAt',
+) => {
   const target = useRef(null);
   const page = useRef(1);
   const [hasNextPage, SetHasNextPage] = useState(true);
@@ -16,7 +23,10 @@ const useIntersect = (api, size, setPosts, setIsPending, threshold = 0) => {
   const getData = useCallback(async () => {
     try {
       setIsPending(true);
-      const { data } = await axios(`${api}size=${size}&page=${page.current}`);
+      console.log(`${api}size=${size}&page=${page.current}&sort=${sort}`);
+      const { data } = await axios(
+        `${api}size=${size}&page=${page.current}&sort=${sort}`,
+      );
       setPosts(prev => [...prev, ...data.content]);
       setIsPending(false);
       SetHasNextPage(data.hasNext);
@@ -28,7 +38,7 @@ const useIntersect = (api, size, setPosts, setIsPending, threshold = 0) => {
     } catch (err) {
       console.log('Error', err.message);
     }
-  }, []);
+  }, [sort]);
 
   useEffect(() => {
     const io = new IntersectionObserver(
@@ -43,9 +53,9 @@ const useIntersect = (api, size, setPosts, setIsPending, threshold = 0) => {
       io.observe(target.current);
     }
     return () => io.disconnect();
-  }, [hasNextPage]);
+  }, [hasNextPage, sort]);
 
-  return target;
+  return [target, page, SetHasNextPage];
 };
 
 export default useIntersect;

--- a/front/src/pages/mainPages/AllThemePage.jsx
+++ b/front/src/pages/mainPages/AllThemePage.jsx
@@ -31,7 +31,7 @@ function AllThemePage() {
 
   return (
     <>
-      <MainSort sortHandler={sortHandler} />
+      <MainSort sort={sort} sortHandler={sortHandler} />
       <div className="main__container">
         {posts.map(post => {
           return <Post key={post.boardId} post={post} />;

--- a/front/src/pages/mainPages/AllThemePage.jsx
+++ b/front/src/pages/mainPages/AllThemePage.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import LoadingSpinner from '../../component/common/LoadingSpinner';
 import Post from '../../component/common/Post';
 import MainSort from '../../component/main/MainSort';
@@ -7,11 +7,31 @@ import useIntersect from '../../hooks/useIntersect';
 function AllThemePage() {
   const [isPending, setIsPending] = useState(true);
   const [posts, setPosts] = useState([]);
-  const target = useIntersect('/boards?', 20, setPosts, setIsPending, 1);
+  const [sort, setSort] = useState('createdAt,desc');
+  const [target, page, hasNext] = useIntersect(
+    '/boards?',
+    20,
+    setPosts,
+    setIsPending,
+    0.7,
+    sort,
+  );
+
+  const sortHandler = sorted => {
+    console.log(sorted);
+    setSort(sorted);
+    target.current.style.display = 'flex';
+    page.current = 1;
+    setPosts([]);
+  };
+
+  useEffect(() => {
+    hasNext(true);
+  }, [sort]);
 
   return (
     <>
-      <MainSort />
+      <MainSort sortHandler={sortHandler} />
       <div className="main__container">
         {posts.map(post => {
           return <Post key={post.boardId} post={post} />;

--- a/front/src/pages/mainPages/RestaurantPage.jsx
+++ b/front/src/pages/mainPages/RestaurantPage.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import LoadingSpinner from '../../component/common/LoadingSpinner';
 import Post from '../../component/common/Post';
 import MainSort from '../../component/main/MainSort';
@@ -7,17 +7,30 @@ import useIntersect from '../../hooks/useIntersect';
 function RestaurantPage() {
   const [isPending, setIsPending] = useState(true);
   const [posts, setPosts] = useState([]);
-  const target = useIntersect(
+  const [sort, setSort] = useState('createdAt,desc');
+  const [target, page, hasNext] = useIntersect(
     '/boards?category=RESTAURANT&',
     20,
     setPosts,
     setIsPending,
-    1,
+    0.7,
+    sort,
   );
 
+  const sortHandler = sorted => {
+    console.log(sorted);
+    setSort(sorted);
+    target.current.style.display = 'flex';
+    page.current = 1;
+    setPosts([]);
+  };
+
+  useEffect(() => {
+    hasNext(true);
+  }, [sort]);
   return (
     <>
-      <MainSort />
+      <MainSort sortHandler={sortHandler} />
       <div className="main__container">
         {posts.map(post => {
           return <Post key={post.boardId} post={post} />;

--- a/front/src/pages/mainPages/SpotPage.jsx
+++ b/front/src/pages/mainPages/SpotPage.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import LoadingSpinner from '../../component/common/LoadingSpinner';
 import Post from '../../component/common/Post';
 import MainSort from '../../component/main/MainSort';
@@ -7,17 +7,31 @@ import useIntersect from '../../hooks/useIntersect';
 function SpotPage() {
   const [isPending, setIsPending] = useState(true);
   const [posts, setPosts] = useState([]);
-  const target = useIntersect(
+  const [sort, setSort] = useState('createdAt,desc');
+  const [target, page, hasNext] = useIntersect(
     '/boards?category=SPOT&',
     20,
     setPosts,
     setIsPending,
-    1,
+    0.7,
+    sort,
   );
+
+  const sortHandler = sorted => {
+    console.log(sorted);
+    setSort(sorted);
+    target.current.style.display = 'flex';
+    page.current = 1;
+    setPosts([]);
+  };
+
+  useEffect(() => {
+    hasNext(true);
+  }, [sort]);
 
   return (
     <>
-      <MainSort />
+      <MainSort sortHandler={sortHandler} />
       <div className="main__container">
         {posts.map(post => {
           return <Post key={post.boardId} post={post} />;

--- a/front/src/pages/mainPages/StayPage.jsx
+++ b/front/src/pages/mainPages/StayPage.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import LoadingSpinner from '../../component/common/LoadingSpinner';
 import Post from '../../component/common/Post';
 import MainSort from '../../component/main/MainSort';
@@ -7,17 +7,31 @@ import useIntersect from '../../hooks/useIntersect';
 function StayPage() {
   const [isPending, setIsPending] = useState(true);
   const [posts, setPosts] = useState([]);
-  const target = useIntersect(
+  const [sort, setSort] = useState('createdAt,desc');
+  const [target, page, hasNext] = useIntersect(
     '/boards?category=STAY&',
     20,
     setPosts,
     setIsPending,
-    1,
+    0.7,
+    sort,
   );
+
+  const sortHandler = sorted => {
+    console.log(sorted);
+    setSort(sorted);
+    target.current.style.display = 'flex';
+    page.current = 1;
+    setPosts([]);
+  };
+
+  useEffect(() => {
+    hasNext(true);
+  }, [sort]);
 
   return (
     <>
-      <MainSort />
+      <MainSort sortHandler={sortHandler} />
       <div className="main__container">
         {posts.map(post => {
           return <Post key={post.boardId} post={post} />;


### PR DESCRIPTION
### 작업목록
1. use옵저버 정렬을 사용함에 따른 수정
2. 조회수가 2회씩 증가하는 부분 수정
3. 전체 및 테마별 정렬 기능 추가
4. 정렬 중복 클릭 방지 추가
### 추가사항
1. 현재 조회순 및 추천순 데이터가 중복으로 들어오는 부분이 발생하여 백엔드 쪽에서 수정을 해줘야 한다. (백엔드와 이야기 완료)

옵저버에 대해서 문의가 있으신분은 말씀해주세요