### PR TITLE
[Fix] 게시글 조회시 중복되어 조회되는 문제 수정

### DIFF
--- a/back/src/main/java/travelRepo/domain/board/repository/BoardRepositoryImpl.java
+++ b/back/src/main/java/travelRepo/domain/board/repository/BoardRepositoryImpl.java
@@ -43,6 +43,7 @@ public class BoardRepositoryImpl implements BoardRepositoryCustom{
         }
 
         sort(pageable, query);
+        query.orderBy(board.id.desc());
 
         List<Board> boards = query.distinct().fetch();
 


### PR DESCRIPTION
게시글 추천/조회 순으로 전체 조회 시 서로 다른 페이지에서 게시글이 중복으로 조회되는 문제가 있었습니다.

아직 정확한 원인은 파악하지 못했지만 게시글, 조회수는 중복되는 값이 많아 정렬이 유일하게 결정되지 않는 것이 문제 같아 우선 정렬 조건을 추가했습니다.