### PR TITLE
[Fix] 데이터가 5개 미만일 때 레이아웃 유지하도록 수정

### DIFF
--- a/front/src/pages/mainPages/MainPage.jsx
+++ b/front/src/pages/mainPages/MainPage.jsx
@@ -27,6 +27,7 @@ const Main = styled.main`
       margin: 0 3rem;
       display: flex;
       flex-wrap: wrap;
+      width: 100%;
 
       @media screen and (max-width: 1440px) {
         .post,

--- a/front/src/pages/myPages/MyLikes.jsx
+++ b/front/src/pages/myPages/MyLikes.jsx
@@ -11,6 +11,7 @@ const MyPageMain = styled.main`
   margin: 0 3rem;
   display: flex;
   flex-wrap: wrap;
+  width: 100%;
 
   .target {
     width: 100%;

--- a/front/src/pages/myPages/MyPost.jsx
+++ b/front/src/pages/myPages/MyPost.jsx
@@ -11,6 +11,7 @@ const MyPageMain = styled.main`
   margin: 0 3rem;
   display: flex;
   flex-wrap: wrap;
+  width: 100%;
 
   .target {
     width: 100%;


### PR DESCRIPTION
데이터가 5개 미만일 때 메인페이지, 마이페이지의 게시글탭, 좋아요탭의 레이아웃이 유지되도록 수정하였습니다.