### PR TITLE
[Refactor] 무한스크롤 페이지네이션 방식 변경

### DIFF
--- a/back/src/docs/asciidoc/index.adoc
+++ b/back/src/docs/asciidoc/index.adoc
@@ -244,6 +244,9 @@ include::{snippets}/accountBoardList/http-request.adoc[]
 .path-parameters
 include::{snippets}/accountBoardList/path-parameters.adoc[]
 
+.request-parameters
+include::{snippets}/accountBoardList/request-parameters.adoc[]
+
 .http-response
 include::{snippets}/accountBoardList/http-response.adoc[]
 
@@ -259,6 +262,9 @@ include::{snippets}/likeBoardList/http-request.adoc[]
 
 .path-parameters
 include::{snippets}/likeBoardList/path-parameters.adoc[]
+
+.request-parameters
+include::{snippets}/likeBoardList/request-parameters.adoc[]
 
 .http-response
 include::{snippets}/likeBoardList/http-response.adoc[]

--- a/back/src/main/java/travelRepo/domain/board/controller/BoardController.java
+++ b/back/src/main/java/travelRepo/domain/board/controller/BoardController.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -14,6 +15,7 @@ import travelRepo.global.common.dto.IdDto;
 import travelRepo.global.common.dto.SliceDto;
 
 import javax.validation.Valid;
+import java.time.LocalDateTime;
 
 @RestController
 @RequestMapping("/boards")
@@ -69,9 +71,10 @@ public class BoardController {
     @GetMapping("/account/{accountId}")
     public ResponseEntity<SliceDto<BoardSummaryRes>> accountBoardList(@PathVariable Long accountId,
                                                                       @RequestParam(required = false) Long lastBoardId,
+                                                                      @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss") LocalDateTime lastBoardCreatedAt,
                                                                       @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
 
-        SliceDto<BoardSummaryRes> response = boardService.findBoardsByAccount(accountId, lastBoardId, pageable);
+        SliceDto<BoardSummaryRes> response = boardService.findBoardsByAccount(accountId, lastBoardId, lastBoardCreatedAt, pageable);
 
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
@@ -79,9 +82,10 @@ public class BoardController {
     @GetMapping("/like/account/{accountId}")
     public ResponseEntity<SliceDto<BoardSummaryResWithLikeId>> likeBoardList(@PathVariable Long accountId,
                                                                              @RequestParam(required = false) Long lastLikeId,
+                                                                             @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss") LocalDateTime lastLikeCreatedAt,
                                                                              @PageableDefault(size = 20) Pageable pageable) {
 
-        SliceDto<BoardSummaryResWithLikeId> response = boardService.findBoardsByLikes(accountId, lastLikeId, pageable);
+        SliceDto<BoardSummaryResWithLikeId> response = boardService.findBoardsByLikes(accountId, lastLikeId, lastLikeCreatedAt, pageable);
 
         return new ResponseEntity<>(response, HttpStatus.OK);
     }

--- a/back/src/main/java/travelRepo/domain/board/controller/BoardController.java
+++ b/back/src/main/java/travelRepo/domain/board/controller/BoardController.java
@@ -77,10 +77,10 @@ public class BoardController {
     }
 
     @GetMapping("/like/account/{accountId}")
-    public ResponseEntity<SliceDto<BoardSummaryRes>> likeBoardList(@PathVariable Long accountId,
+    public ResponseEntity<SliceDto<BoardSummaryResWithLikeId>> likeBoardList(@PathVariable Long accountId,
                                                                    @PageableDefault(size = 20) Pageable pageable) {
 
-        SliceDto<BoardSummaryRes> response = boardService.findBoardsByLikes(accountId, pageable);
+        SliceDto<BoardSummaryResWithLikeId> response = boardService.findBoardsByLikes(accountId, pageable);
 
         return new ResponseEntity<>(response, HttpStatus.OK);
     }

--- a/back/src/main/java/travelRepo/domain/board/controller/BoardController.java
+++ b/back/src/main/java/travelRepo/domain/board/controller/BoardController.java
@@ -68,9 +68,10 @@ public class BoardController {
 
     @GetMapping("/account/{accountId}")
     public ResponseEntity<SliceDto<BoardSummaryRes>> accountBoardList(@PathVariable Long accountId,
+                                                                      @RequestParam(required = false) Long lastBoardId,
                                                                       @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
 
-        SliceDto<BoardSummaryRes> response = boardService.findBoardsByAccount(accountId, pageable);
+        SliceDto<BoardSummaryRes> response = boardService.findBoardsByAccount(accountId, lastBoardId, pageable);
 
         return new ResponseEntity<>(response, HttpStatus.OK);
     }

--- a/back/src/main/java/travelRepo/domain/board/controller/BoardController.java
+++ b/back/src/main/java/travelRepo/domain/board/controller/BoardController.java
@@ -7,11 +7,7 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import travelRepo.domain.board.dto.BoardAddReq;
-import travelRepo.domain.board.dto.BoardDetailsRes;
-import travelRepo.domain.board.dto.BoardModifyReq;
-import travelRepo.domain.board.dto.BoardSummaryRes;
-import travelRepo.domain.board.entity.Category;
+import travelRepo.domain.board.dto.*;
 import travelRepo.domain.board.service.BoardService;
 import travelRepo.global.argumentresolver.LoginAccountId;
 import travelRepo.global.common.dto.IdDto;
@@ -62,11 +58,10 @@ public class BoardController {
     }
 
     @GetMapping
-    public ResponseEntity<SliceDto<BoardSummaryRes>> boardList(@RequestParam(required = false) String query,
-                                                               @RequestParam(required = false) Category category,
+    public ResponseEntity<SliceDto<BoardSummaryRes>> boardList(@ModelAttribute BoardListReq boardListReq,
                                                                @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
 
-        SliceDto<BoardSummaryRes> response = boardService.findBoards(query, category, pageable);
+        SliceDto<BoardSummaryRes> response = boardService.findBoards(boardListReq, pageable);
 
         return new ResponseEntity<>(response, HttpStatus.OK);
     }

--- a/back/src/main/java/travelRepo/domain/board/controller/BoardController.java
+++ b/back/src/main/java/travelRepo/domain/board/controller/BoardController.java
@@ -78,9 +78,10 @@ public class BoardController {
 
     @GetMapping("/like/account/{accountId}")
     public ResponseEntity<SliceDto<BoardSummaryResWithLikeId>> likeBoardList(@PathVariable Long accountId,
-                                                                   @PageableDefault(size = 20) Pageable pageable) {
+                                                                             @RequestParam(required = false) Long lastLikeId,
+                                                                             @PageableDefault(size = 20) Pageable pageable) {
 
-        SliceDto<BoardSummaryResWithLikeId> response = boardService.findBoardsByLikes(accountId, pageable);
+        SliceDto<BoardSummaryResWithLikeId> response = boardService.findBoardsByLikes(accountId, lastLikeId, pageable);
 
         return new ResponseEntity<>(response, HttpStatus.OK);
     }

--- a/back/src/main/java/travelRepo/domain/board/dto/BoardDetailsRes.java
+++ b/back/src/main/java/travelRepo/domain/board/dto/BoardDetailsRes.java
@@ -65,7 +65,7 @@ public class BoardDetailsRes {
                         .map(BoardPhoto::getPhoto)
                         .collect(Collectors.toList())
         );
-        boardDetailsRes.setCreatedAt(board.getCreatedAt());
+        boardDetailsRes.setCreatedAt(board.getCreatedAt().withNano(0));
         boardDetailsRes.setAccount(AccountSummaryRes.of(board.getAccount()));
 
         return boardDetailsRes;

--- a/back/src/main/java/travelRepo/domain/board/dto/BoardListReq.java
+++ b/back/src/main/java/travelRepo/domain/board/dto/BoardListReq.java
@@ -1,0 +1,18 @@
+package travelRepo.domain.board.dto;
+
+import lombok.Data;
+import travelRepo.domain.board.entity.Category;
+
+@Data
+public class BoardListReq {
+
+    private String query = "";
+
+    private Category category;
+
+    private Long lastBoardId;
+
+    private Integer lastBoardViews;
+
+    private Integer lastBoardLikeCount;
+}

--- a/back/src/main/java/travelRepo/domain/board/dto/BoardListReq.java
+++ b/back/src/main/java/travelRepo/domain/board/dto/BoardListReq.java
@@ -1,7 +1,10 @@
 package travelRepo.domain.board.dto;
 
 import lombok.Data;
+import org.springframework.format.annotation.DateTimeFormat;
 import travelRepo.domain.board.entity.Category;
+
+import java.time.LocalDateTime;
 
 @Data
 public class BoardListReq {
@@ -11,6 +14,9 @@ public class BoardListReq {
     private Category category;
 
     private Long lastBoardId;
+
+    @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime lastBoardCreatedAt;
 
     private Integer lastBoardViews;
 

--- a/back/src/main/java/travelRepo/domain/board/dto/BoardSummaryRes.java
+++ b/back/src/main/java/travelRepo/domain/board/dto/BoardSummaryRes.java
@@ -20,6 +20,8 @@ public class BoardSummaryRes {
 
     private int likeCount;
 
+    private int views;
+
     private List<String> tags;
 
     private AccountSummaryRes account;
@@ -31,6 +33,7 @@ public class BoardSummaryRes {
         boardSummaryRes.setThumbnail(board.getThumbnail());
         boardSummaryRes.setTitle(board.getTitle());
         boardSummaryRes.setLikeCount(board.getLikeCount());
+        boardSummaryRes.setViews(board.getViews());
         boardSummaryRes.setTags(
                 board.getBoardTags().stream()
                         .sorted(Comparator.comparing(BoardTag::getOrders))

--- a/back/src/main/java/travelRepo/domain/board/dto/BoardSummaryRes.java
+++ b/back/src/main/java/travelRepo/domain/board/dto/BoardSummaryRes.java
@@ -5,6 +5,7 @@ import travelRepo.domain.account.dto.AccountSummaryRes;
 import travelRepo.domain.board.entity.Board;
 import travelRepo.domain.board.entity.BoardTag;
 
+import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -22,6 +23,8 @@ public class BoardSummaryRes {
 
     private int views;
 
+    private LocalDateTime createdAt;
+
     private List<String> tags;
 
     private AccountSummaryRes account;
@@ -34,6 +37,7 @@ public class BoardSummaryRes {
         boardSummaryRes.setTitle(board.getTitle());
         boardSummaryRes.setLikeCount(board.getLikeCount());
         boardSummaryRes.setViews(board.getViews());
+        boardSummaryRes.setCreatedAt(board.getCreatedAt());
         boardSummaryRes.setTags(
                 board.getBoardTags().stream()
                         .sorted(Comparator.comparing(BoardTag::getOrders))

--- a/back/src/main/java/travelRepo/domain/board/dto/BoardSummaryRes.java
+++ b/back/src/main/java/travelRepo/domain/board/dto/BoardSummaryRes.java
@@ -37,7 +37,7 @@ public class BoardSummaryRes {
         boardSummaryRes.setTitle(board.getTitle());
         boardSummaryRes.setLikeCount(board.getLikeCount());
         boardSummaryRes.setViews(board.getViews());
-        boardSummaryRes.setCreatedAt(board.getCreatedAt());
+        boardSummaryRes.setCreatedAt(board.getCreatedAt().withNano(0));
         boardSummaryRes.setTags(
                 board.getBoardTags().stream()
                         .sorted(Comparator.comparing(BoardTag::getOrders))

--- a/back/src/main/java/travelRepo/domain/board/dto/BoardSummaryResWithLikeId.java
+++ b/back/src/main/java/travelRepo/domain/board/dto/BoardSummaryResWithLikeId.java
@@ -5,6 +5,7 @@ import travelRepo.domain.account.dto.AccountSummaryRes;
 import travelRepo.domain.board.entity.Board;
 import travelRepo.domain.board.entity.BoardTag;
 
+import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -14,7 +15,6 @@ public class BoardSummaryResWithLikeId {
 
     private Long boardId;
 
-    private Long likeId;
 
     private String thumbnail;
 
@@ -23,6 +23,10 @@ public class BoardSummaryResWithLikeId {
     private int likeCount;
 
     private List<String> tags;
+
+    private Long likeId;
+
+    private LocalDateTime likeCreatedAt;
 
     private AccountSummaryRes account;
 

--- a/back/src/main/java/travelRepo/domain/board/dto/BoardSummaryResWithLikeId.java
+++ b/back/src/main/java/travelRepo/domain/board/dto/BoardSummaryResWithLikeId.java
@@ -1,0 +1,46 @@
+package travelRepo.domain.board.dto;
+
+import lombok.Data;
+import travelRepo.domain.account.dto.AccountSummaryRes;
+import travelRepo.domain.board.entity.Board;
+import travelRepo.domain.board.entity.BoardTag;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Data
+public class BoardSummaryResWithLikeId {
+
+    private Long boardId;
+
+    private Long likeId;
+
+    private String thumbnail;
+
+    private String title;
+
+    private int likeCount;
+
+    private List<String> tags;
+
+    private AccountSummaryRes account;
+
+    static public BoardSummaryResWithLikeId of(Board board) {
+
+        BoardSummaryResWithLikeId boardSummaryRes = new BoardSummaryResWithLikeId();
+        boardSummaryRes.setBoardId(board.getId());
+        boardSummaryRes.setThumbnail(board.getThumbnail());
+        boardSummaryRes.setTitle(board.getTitle());
+        boardSummaryRes.setLikeCount(board.getLikeCount());
+        boardSummaryRes.setTags(
+                board.getBoardTags().stream()
+                        .sorted(Comparator.comparing(BoardTag::getOrders))
+                        .map(boardTag -> boardTag.getTag().getName())
+                        .collect(Collectors.toList())
+        );
+        boardSummaryRes.setAccount(AccountSummaryRes.of(board.getAccount()));
+
+        return boardSummaryRes;
+    }
+}

--- a/back/src/main/java/travelRepo/domain/board/repository/BoardRepository.java
+++ b/back/src/main/java/travelRepo/domain/board/repository/BoardRepository.java
@@ -7,7 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import travelRepo.domain.account.entity.Account;
 import travelRepo.domain.board.entity.Board;
 
 import java.util.List;

--- a/back/src/main/java/travelRepo/domain/board/repository/BoardRepository.java
+++ b/back/src/main/java/travelRepo/domain/board/repository/BoardRepository.java
@@ -1,7 +1,5 @@
 package travelRepo.domain.board.repository;
 
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -21,18 +19,6 @@ public interface BoardRepository extends JpaRepository<Board, Long>, BoardReposi
     @EntityGraph(attributePaths = {"boardTags", "account"})
     @Query("select b from Board b where b.id = :boardId")
     Optional<Board> findByIdWithBoardTagsAndAccount(@Param("boardId") Long boardId);
-
-    @EntityGraph(attributePaths = {"boardTags", "account"})
-    @Query("select b from Board b where b.account.id = :accountId")
-    Slice<Board> findAllByAccountIdWithBoardTagsAndAccountBefore(@Param("accountId") Long accountId, Pageable pageable);
-
-    @EntityGraph(attributePaths = {"boardTags", "account"})
-    @Query("select b from Board b where b.account.id = :accountId and b.id < :lastBoardId")
-    Slice<Board> findAllByAccountIdWithBoardTagsAndAccount(@Param("accountId") Long accountId, @Param("lastBoardId") Long lastBoardId, Pageable pageable);
-
-    @EntityGraph(attributePaths = {"boardTags", "account"})
-    @Query("select b from Board b left join Likes l on b.id = l.board.id where l.account.id = :accountId order by l.createdAt desc")
-    Slice<Board> findAllByAccountLikesWithBoardTagsAndAccount(@Param("accountId") Long accountId, Pageable pageable);
 
     @Modifying
     @Query("update Board b set b.views = :views where b.id = :boardId")

--- a/back/src/main/java/travelRepo/domain/board/repository/BoardRepository.java
+++ b/back/src/main/java/travelRepo/domain/board/repository/BoardRepository.java
@@ -24,7 +24,11 @@ public interface BoardRepository extends JpaRepository<Board, Long>, BoardReposi
 
     @EntityGraph(attributePaths = {"boardTags", "account"})
     @Query("select b from Board b where b.account.id = :accountId")
-    Slice<Board> findAllByAccountIdWithBoardTagsAndAccount(@Param("accountId") Long accountId, Pageable pageable);
+    Slice<Board> findAllByAccountIdWithBoardTagsAndAccountBefore(@Param("accountId") Long accountId, Pageable pageable);
+
+    @EntityGraph(attributePaths = {"boardTags", "account"})
+    @Query("select b from Board b where b.account.id = :accountId and b.id < :lastBoardId")
+    Slice<Board> findAllByAccountIdWithBoardTagsAndAccount(@Param("accountId") Long accountId, @Param("lastBoardId") Long lastBoardId, Pageable pageable);
 
     @EntityGraph(attributePaths = {"boardTags", "account"})
     @Query("select b from Board b left join Likes l on b.id = l.board.id where l.account.id = :accountId order by l.createdAt desc")

--- a/back/src/main/java/travelRepo/domain/board/repository/BoardRepositoryCustom.java
+++ b/back/src/main/java/travelRepo/domain/board/repository/BoardRepositoryCustom.java
@@ -2,10 +2,10 @@ package travelRepo.domain.board.repository;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
+import travelRepo.domain.board.dto.BoardListReq;
 import travelRepo.domain.board.entity.Board;
-import travelRepo.domain.board.entity.Category;
 
 public interface BoardRepositoryCustom {
 
-    Slice<Board> findAllByQueries(String[] queries, Category category, Pageable pageable);
+    Slice<Board> findAllByQueries(String[] queries, Pageable pageable, BoardListReq boardListReq);
 }

--- a/back/src/main/java/travelRepo/domain/board/repository/BoardRepositoryCustom.java
+++ b/back/src/main/java/travelRepo/domain/board/repository/BoardRepositoryCustom.java
@@ -8,4 +8,8 @@ import travelRepo.domain.board.entity.Board;
 public interface BoardRepositoryCustom {
 
     Slice<Board> findAllByQueries(String[] queries, Pageable pageable, BoardListReq boardListReq);
+
+    Slice<Board> findAllByAccountIdWithBoardTagsAndAccount(Long accountId, Long lastBoardId, Pageable pageable);
+
+    Slice<Board> findAllByAccountLikesWithBoardTagsAndAccount(Long accountId, Long lastLikeId, Pageable pageable);
 }

--- a/back/src/main/java/travelRepo/domain/board/repository/BoardRepositoryCustom.java
+++ b/back/src/main/java/travelRepo/domain/board/repository/BoardRepositoryCustom.java
@@ -5,11 +5,13 @@ import org.springframework.data.domain.Slice;
 import travelRepo.domain.board.dto.BoardListReq;
 import travelRepo.domain.board.entity.Board;
 
+import java.time.LocalDateTime;
+
 public interface BoardRepositoryCustom {
 
     Slice<Board> findAllByQueries(String[] queries, Pageable pageable, BoardListReq boardListReq);
 
-    Slice<Board> findAllByAccountIdWithBoardTagsAndAccount(Long accountId, Long lastBoardId, Pageable pageable);
+    Slice<Board> findAllByAccountIdWithBoardTagsAndAccount(Long accountId, Long lastBoardId, LocalDateTime lastBoardCreatedAt, Pageable pageable);
 
-    Slice<Board> findAllByAccountLikesWithBoardTagsAndAccount(Long accountId, Long lastLikeId, Pageable pageable);
+    Slice<Board> findAllByAccountLikesWithBoardTagsAndAccount(Long accountId, Long lastLikeId, LocalDateTime lastLikeCreatedAt, Pageable pageable);
 }

--- a/back/src/main/java/travelRepo/domain/board/repository/BoardRepositoryImpl.java
+++ b/back/src/main/java/travelRepo/domain/board/repository/BoardRepositoryImpl.java
@@ -75,7 +75,7 @@ public class BoardRepositoryImpl implements BoardRepositoryCustom{
     public Slice<Board> findAllByAccountLikesWithBoardTagsAndAccount(Long accountId, Long lastLikeId, Pageable pageable) {
 
         JPAQuery<Board> query = jpaQueryFactory
-                .selectFrom(board).distinct()
+                .selectFrom(board)
                 .leftJoin(likes).on(board.id.eq(likes.board.id))
                 .where(likes.account.id.eq(accountId))
                 .orderBy(likes.createdAt.desc())

--- a/back/src/main/java/travelRepo/domain/board/repository/BoardRepositoryImpl.java
+++ b/back/src/main/java/travelRepo/domain/board/repository/BoardRepositoryImpl.java
@@ -43,6 +43,7 @@ public class BoardRepositoryImpl implements BoardRepositoryCustom{
         }
 
         sort(pageable, query);
+        query.orderBy(board.id.desc());
 
         List<Board> boards = query.distinct().fetch();
 

--- a/back/src/main/java/travelRepo/domain/board/service/BoardService.java
+++ b/back/src/main/java/travelRepo/domain/board/service/BoardService.java
@@ -25,6 +25,7 @@ import travelRepo.global.common.dto.SliceDto;
 import travelRepo.global.exception.BusinessLogicException;
 import travelRepo.global.exception.ExceptionCode;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -124,16 +125,16 @@ public class BoardService {
         return response;
     }
 
-    public SliceDto<BoardSummaryRes> findBoardsByAccount(Long accountId, Long lastBoardId, Pageable pageable) {
+    public SliceDto<BoardSummaryRes> findBoardsByAccount(Long accountId, Long lastBoardId, LocalDateTime lastBoardCreatedAt, Pageable pageable) {
 
-        Slice<Board> boards = boardRepository.findAllByAccountIdWithBoardTagsAndAccount(accountId, lastBoardId, pageable);
+        Slice<Board> boards = boardRepository.findAllByAccountIdWithBoardTagsAndAccount(accountId, lastBoardId, lastBoardCreatedAt, pageable);
 
         return new SliceDto<>(boards.map(BoardSummaryRes::of));
     }
 
-    public SliceDto<BoardSummaryResWithLikeId> findBoardsByLikes(Long accountId, Long lastLikeId, Pageable pageable) {
+    public SliceDto<BoardSummaryResWithLikeId> findBoardsByLikes(Long accountId, Long lastLikeId, LocalDateTime lastLikeCreatedAt, Pageable pageable) {
 
-        Slice<Board> boards = boardRepository.findAllByAccountLikesWithBoardTagsAndAccount(accountId, lastLikeId, pageable);
+        Slice<Board> boards = boardRepository.findAllByAccountLikesWithBoardTagsAndAccount(accountId, lastLikeId, lastLikeCreatedAt, pageable);
 
         SliceDto<BoardSummaryResWithLikeId> response = new SliceDto<>(boards.map(BoardSummaryResWithLikeId::of));
 
@@ -212,7 +213,7 @@ public class BoardService {
 
         for (int i = 0; i < likes.size(); i++) {
             response.getContent().get(i).setLikeId(likes.get(i).getId());
-            response.getContent().get(i).setLikeCreatedAt(likes.get(i).getCreatedAt());
+            response.getContent().get(i).setLikeCreatedAt(likes.get(i).getCreatedAt().withNano(0));
         }
     }
 

--- a/back/src/main/java/travelRepo/domain/board/service/BoardService.java
+++ b/back/src/main/java/travelRepo/domain/board/service/BoardService.java
@@ -122,9 +122,15 @@ public class BoardService {
         return response;
     }
 
-    public SliceDto<BoardSummaryRes> findBoardsByAccount(Long accountId, Pageable pageable) {
+    public SliceDto<BoardSummaryRes> findBoardsByAccount(Long accountId, Long lastBoardId, Pageable pageable) {
 
-        Slice<Board> boards = boardRepository.findAllByAccountIdWithBoardTagsAndAccount(accountId, pageable);
+        Slice<Board> boards;
+        if (lastBoardId == null) {
+            boards = boardRepository.findAllByAccountIdWithBoardTagsAndAccountBefore(accountId, pageable);
+        } else {
+            boards = boardRepository.findAllByAccountIdWithBoardTagsAndAccount(accountId, lastBoardId, pageable);
+            System.out.println("======================" + lastBoardId);
+        }
 
         SliceDto<BoardSummaryRes> response = new SliceDto<>(boards.map(BoardSummaryRes::of));
         setRedisBoardViewsToRes(response);

--- a/back/src/main/java/travelRepo/domain/board/service/BoardService.java
+++ b/back/src/main/java/travelRepo/domain/board/service/BoardService.java
@@ -126,20 +126,14 @@ public class BoardService {
 
     public SliceDto<BoardSummaryRes> findBoardsByAccount(Long accountId, Long lastBoardId, Pageable pageable) {
 
-        Slice<Board> boards;
-
-        if (lastBoardId == null) {
-            boards = boardRepository.findAllByAccountIdWithBoardTagsAndAccountBefore(accountId, pageable);
-        } else {
-            boards = boardRepository.findAllByAccountIdWithBoardTagsAndAccount(accountId, lastBoardId, pageable);
-        }
+        Slice<Board> boards = boardRepository.findAllByAccountIdWithBoardTagsAndAccount(accountId, lastBoardId, pageable);
 
         return new SliceDto<>(boards.map(BoardSummaryRes::of));
     }
 
-    public SliceDto<BoardSummaryResWithLikeId> findBoardsByLikes(Long accountId, Pageable pageable) {
+    public SliceDto<BoardSummaryResWithLikeId> findBoardsByLikes(Long accountId, Long lastLikeId, Pageable pageable) {
 
-        Slice<Board> boards = boardRepository.findAllByAccountLikesWithBoardTagsAndAccount(accountId, pageable);
+        Slice<Board> boards = boardRepository.findAllByAccountLikesWithBoardTagsAndAccount(accountId, lastLikeId, pageable);
 
         SliceDto<BoardSummaryResWithLikeId> response = new SliceDto<>(boards.map(BoardSummaryResWithLikeId::of));
 

--- a/back/src/main/java/travelRepo/domain/board/service/BoardService.java
+++ b/back/src/main/java/travelRepo/domain/board/service/BoardService.java
@@ -3,22 +3,15 @@ package travelRepo.domain.board.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
-import org.springframework.dao.DataAccessException;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
-import org.springframework.data.redis.connection.RedisConnection;
-import org.springframework.data.redis.core.RedisCallback;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import travelRepo.domain.account.entity.Account;
 import travelRepo.domain.account.repository.AccountRepository;
-import travelRepo.domain.board.dto.BoardAddReq;
-import travelRepo.domain.board.dto.BoardDetailsRes;
-import travelRepo.domain.board.dto.BoardModifyReq;
-import travelRepo.domain.board.dto.BoardSummaryRes;
+import travelRepo.domain.board.dto.*;
 import travelRepo.domain.board.entity.*;
 import travelRepo.domain.board.repository.BoardPhotoRepository;
 import travelRepo.domain.board.repository.BoardRepository;
@@ -33,7 +26,6 @@ import travelRepo.global.exception.ExceptionCode;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
@@ -117,15 +109,11 @@ public class BoardService {
         return BoardDetailsRes.of(board);
     }
 
-    public SliceDto<BoardSummaryRes> findBoards(String query, Category category, Pageable pageable) {
+    public SliceDto<BoardSummaryRes> findBoards(BoardListReq boardListReq, Pageable pageable) {
 
-        if (query == null) {
-            query = "";
-        }
+        String[] queries = boardListReq.getQuery().strip().split("\\s+");
 
-        String[] queries = query.strip().split("\\s+");
-
-        Slice<Board> boards = boardRepository.findAllByQueries(queries, category, pageable);
+        Slice<Board> boards = boardRepository.findAllByQueries(queries, pageable, boardListReq);
 
         return new SliceDto<>(boards.map(BoardSummaryRes::of));
     }

--- a/back/src/main/java/travelRepo/domain/board/service/BoardService.java
+++ b/back/src/main/java/travelRepo/domain/board/service/BoardService.java
@@ -137,7 +137,7 @@ public class BoardService {
 
         SliceDto<BoardSummaryResWithLikeId> response = new SliceDto<>(boards.map(BoardSummaryResWithLikeId::of));
 
-        setLikeCountToRes(accountId, boards, response);
+        setLikeIdToRes(accountId, boards, response);
 
         return response;
     }
@@ -202,7 +202,7 @@ public class BoardService {
         }
     }
 
-    private void setLikeCountToRes(Long accountId, Slice<Board> boards, SliceDto<BoardSummaryResWithLikeId> response) {
+    private void setLikeIdToRes(Long accountId, Slice<Board> boards, SliceDto<BoardSummaryResWithLikeId> response) {
 
         List<Long> boardIds = boards.getContent().stream()
                 .map(Board::getId)

--- a/back/src/main/java/travelRepo/domain/board/service/BoardService.java
+++ b/back/src/main/java/travelRepo/domain/board/service/BoardService.java
@@ -137,7 +137,7 @@ public class BoardService {
 
         SliceDto<BoardSummaryResWithLikeId> response = new SliceDto<>(boards.map(BoardSummaryResWithLikeId::of));
 
-        setLikeIdToRes(accountId, boards, response);
+        setLikesDataToRes(accountId, boards, response);
 
         return response;
     }
@@ -202,7 +202,7 @@ public class BoardService {
         }
     }
 
-    private void setLikeIdToRes(Long accountId, Slice<Board> boards, SliceDto<BoardSummaryResWithLikeId> response) {
+    private void setLikesDataToRes(Long accountId, Slice<Board> boards, SliceDto<BoardSummaryResWithLikeId> response) {
 
         List<Long> boardIds = boards.getContent().stream()
                 .map(Board::getId)
@@ -210,9 +210,9 @@ public class BoardService {
 
         List<Likes> likes = likesRepository.findByAccountIdAndBoardIds(accountId, boardIds);
 
-
         for (int i = 0; i < likes.size(); i++) {
             response.getContent().get(i).setLikeId(likes.get(i).getId());
+            response.getContent().get(i).setLikeCreatedAt(likes.get(i).getCreatedAt());
         }
     }
 

--- a/back/src/main/java/travelRepo/domain/comment/controller/CommentController.java
+++ b/back/src/main/java/travelRepo/domain/comment/controller/CommentController.java
@@ -50,9 +50,10 @@ public class CommentController {
 
     @GetMapping("/board/{boardId}")
     public ResponseEntity<SliceDto<CommentDetailsRes>> commentList(@PathVariable Long boardId,
+                                                                   @RequestParam(required = false) Long lastCommentId,
                                                                    @PageableDefault(size = 5, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
 
-        SliceDto<CommentDetailsRes> response = commentService.commentList(boardId, pageable);
+        SliceDto<CommentDetailsRes> response = commentService.commentList(boardId, lastCommentId,  pageable);
 
         return new ResponseEntity<>(response, HttpStatus.OK);
     }

--- a/back/src/main/java/travelRepo/domain/comment/controller/CommentController.java
+++ b/back/src/main/java/travelRepo/domain/comment/controller/CommentController.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -15,6 +16,7 @@ import travelRepo.global.argumentresolver.LoginAccountId;
 import travelRepo.global.common.dto.SliceDto;
 
 import javax.validation.Valid;
+import java.time.LocalDateTime;
 
 @RestController
 @RequestMapping("/comments")
@@ -51,9 +53,10 @@ public class CommentController {
     @GetMapping("/board/{boardId}")
     public ResponseEntity<SliceDto<CommentDetailsRes>> commentList(@PathVariable Long boardId,
                                                                    @RequestParam(required = false) Long lastCommentId,
+                                                                   @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss") LocalDateTime lastCommentCreatedAt,
                                                                    @PageableDefault(size = 5, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
 
-        SliceDto<CommentDetailsRes> response = commentService.commentList(boardId, lastCommentId,  pageable);
+        SliceDto<CommentDetailsRes> response = commentService.commentList(boardId, lastCommentId, lastCommentCreatedAt, pageable);
 
         return new ResponseEntity<>(response, HttpStatus.OK);
     }

--- a/back/src/main/java/travelRepo/domain/comment/dto/CommentDetailsRes.java
+++ b/back/src/main/java/travelRepo/domain/comment/dto/CommentDetailsRes.java
@@ -22,7 +22,7 @@ public class CommentDetailsRes {
         CommentDetailsRes commentDetailsRes = new CommentDetailsRes();
         commentDetailsRes.setCommentId(comment.getId());
         commentDetailsRes.setContent(comment.getContent());
-        commentDetailsRes.setCreatedAt(comment.getCreatedAt());
+        commentDetailsRes.setCreatedAt(comment.getCreatedAt().withNano(0));
         commentDetailsRes.setAccount(AccountSummaryRes.of(comment.getAccount()));
 
         return commentDetailsRes;

--- a/back/src/main/java/travelRepo/domain/comment/repository/CommentRepository.java
+++ b/back/src/main/java/travelRepo/domain/comment/repository/CommentRepository.java
@@ -26,5 +26,10 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     @Query("select c from Comment c where c.id = :commentId")
     Optional<Comment> findByIdWithAccount(@Param("commentId") Long commentId);
 
+    @EntityGraph(attributePaths = {"account"})
     Slice<Comment> findAllByBoard_Id(Long boardsId, Pageable pageable);
+
+    @EntityGraph(attributePaths = {"account"})
+    @Query("select c from Comment c where c.board.id = :boardId and c.id < :lastCommentId")
+    Slice<Comment> findAllAfterLastByBoardId(@Param("boardId") Long boardId, @Param("lastCommentId") Long lastCommentId, Pageable pageable);
 }

--- a/back/src/main/java/travelRepo/domain/comment/repository/CommentRepository.java
+++ b/back/src/main/java/travelRepo/domain/comment/repository/CommentRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import travelRepo.domain.comment.entity.Comment;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
@@ -30,6 +31,8 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     Slice<Comment> findAllByBoard_Id(Long boardsId, Pageable pageable);
 
     @EntityGraph(attributePaths = {"account"})
-    @Query("select c from Comment c where c.board.id = :boardId and c.id < :lastCommentId")
-    Slice<Comment> findAllAfterLastByBoardId(@Param("boardId") Long boardId, @Param("lastCommentId") Long lastCommentId, Pageable pageable);
+    @Query("select c from Comment c where c.board.id = :boardId " +
+            "and (c.createdAt < :lastCommentCreatedAt or (c.createdAt = :lastCommentCreatedAt and c.id < :lastCommentId))")
+    Slice<Comment> findAllAfterLastByBoardId(@Param("boardId") Long boardId, @Param("lastCommentId") Long lastCommentId
+            , @Param("lastCommentCreatedAt") LocalDateTime lastCommentCreatedAt, Pageable pageable);
 }

--- a/back/src/main/java/travelRepo/domain/comment/service/CommentService.java
+++ b/back/src/main/java/travelRepo/domain/comment/service/CommentService.java
@@ -67,9 +67,15 @@ public class CommentService {
         commentRepository.delete(comment);
     }
     
-    public SliceDto<CommentDetailsRes> commentList(Long boardId, Pageable pageable) {
+    public SliceDto<CommentDetailsRes> commentList(Long boardId, Long lastCommentId, Pageable pageable) {
 
-        Slice<Comment> comments = commentRepository.findAllByBoard_Id(boardId, pageable);
+        Slice<Comment> comments;
+
+        if (lastCommentId == null) {
+            comments = commentRepository.findAllByBoard_Id(boardId, pageable);
+        } else {
+            comments = commentRepository.findAllAfterLastByBoardId(boardId, lastCommentId, pageable);
+        }
 
         return new SliceDto<>(comments.map(CommentDetailsRes::of));
     }

--- a/back/src/main/java/travelRepo/domain/comment/service/CommentService.java
+++ b/back/src/main/java/travelRepo/domain/comment/service/CommentService.java
@@ -18,6 +18,8 @@ import travelRepo.global.common.dto.SliceDto;
 import travelRepo.global.exception.BusinessLogicException;
 import travelRepo.global.exception.ExceptionCode;
 
+import java.time.LocalDateTime;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -67,14 +69,14 @@ public class CommentService {
         commentRepository.delete(comment);
     }
     
-    public SliceDto<CommentDetailsRes> commentList(Long boardId, Long lastCommentId, Pageable pageable) {
+    public SliceDto<CommentDetailsRes> commentList(Long boardId, Long lastCommentId, LocalDateTime lastCommentCreatedAt, Pageable pageable) {
 
         Slice<Comment> comments;
 
         if (lastCommentId == null) {
             comments = commentRepository.findAllByBoard_Id(boardId, pageable);
         } else {
-            comments = commentRepository.findAllAfterLastByBoardId(boardId, lastCommentId, pageable);
+            comments = commentRepository.findAllAfterLastByBoardId(boardId, lastCommentId, lastCommentCreatedAt, pageable);
         }
 
         return new SliceDto<>(comments.map(CommentDetailsRes::of));

--- a/back/src/main/java/travelRepo/domain/likes/likesRepository/LikesRepository.java
+++ b/back/src/main/java/travelRepo/domain/likes/likesRepository/LikesRepository.java
@@ -8,9 +8,13 @@ import travelRepo.domain.account.entity.Account;
 import travelRepo.domain.board.entity.Board;
 import travelRepo.domain.likes.entity.Likes;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface LikesRepository extends JpaRepository<Likes, Long> {
+
+    @Query("select l from Likes l where l.account.id = :accountId and l.board.id in (:boardIds) order by l.id")
+    List<Likes> findByAccountIdAndBoardIds(@Param("accountId") Long accountId, @Param("boardIds") List<Long> boardIds);
 
     @Modifying(flushAutomatically = true)
     @Query("delete from Likes likes where likes.account.id = :accountId " +

--- a/back/src/main/java/travelRepo/domain/likes/likesRepository/LikesRepository.java
+++ b/back/src/main/java/travelRepo/domain/likes/likesRepository/LikesRepository.java
@@ -13,7 +13,7 @@ import java.util.Optional;
 
 public interface LikesRepository extends JpaRepository<Likes, Long> {
 
-    @Query("select l from Likes l where l.account.id = :accountId and l.board.id in (:boardIds) order by l.createdAt")
+    @Query("select l from Likes l where l.account.id = :accountId and l.board.id in (:boardIds) order by l.createdAt desc")
     List<Likes> findByAccountIdAndBoardIds(@Param("accountId") Long accountId, @Param("boardIds") List<Long> boardIds);
 
     @Modifying(flushAutomatically = true)

--- a/back/src/main/java/travelRepo/domain/likes/likesRepository/LikesRepository.java
+++ b/back/src/main/java/travelRepo/domain/likes/likesRepository/LikesRepository.java
@@ -13,7 +13,7 @@ import java.util.Optional;
 
 public interface LikesRepository extends JpaRepository<Likes, Long> {
 
-    @Query("select l from Likes l where l.account.id = :accountId and l.board.id in (:boardIds) order by l.id")
+    @Query("select l from Likes l where l.account.id = :accountId and l.board.id in (:boardIds) order by l.createdAt")
     List<Likes> findByAccountIdAndBoardIds(@Param("accountId") Long accountId, @Param("boardIds") List<Long> boardIds);
 
     @Modifying(flushAutomatically = true)

--- a/back/src/main/resources/static/docs/index.html
+++ b/back/src/main/resources/static/docs/index.html
@@ -571,7 +571,7 @@ Host: localhost:8080
 Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njk1NDA5MDgsImV4cCI6MTY2OTU0NDUwOH0.SynFFvL0cFywlCNoF_aCi763xtU8uemL5mYR9Kuol7U
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njk1OTcwNzksImV4cCI6MTY2OTYwMDY3OX0.EZQVYjQY1yVPcKc6n4-FR6Fiw-DHclXlzuSugmASQWY
 X-Content-Type-Options: nosniff
 X-XSS-Protection: 1; mode=block
 Cache-Control: no-cache, no-store, max-age=0, must-revalidate
@@ -750,7 +750,7 @@ Content-Length: 16
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/accounts/modify' -i -X POST \
     -H 'Content-Type: application/json;charset=UTF-8' \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njk1NDA5MDcsImV4cCI6MTY2OTU0NDUwN30.1DyWQu-RB_2kMtG-jJSys7ujYpIOXWIWJNvMJ0ZVEW4' \
+    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njk1OTcwNzgsImV4cCI6MTY2OTYwMDY3OH0.NETJuOBG8PGvUt2ToYkTyF-Kn-f1cSEPxfbJwEW8ZGY' \
     -H 'Accept: application/json' \
     -d '{
   "password" : "123456789",
@@ -765,7 +765,7 @@ Content-Length: 16
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">POST /accounts/modify HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njk1NDA5MDcsImV4cCI6MTY2OTU0NDUwN30.1DyWQu-RB_2kMtG-jJSys7ujYpIOXWIWJNvMJ0ZVEW4
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njk1OTcwNzgsImV4cCI6MTY2OTYwMDY3OH0.NETJuOBG8PGvUt2ToYkTyF-Kn-f1cSEPxfbJwEW8ZGY
 Accept: application/json
 Content-Length: 130
 Host: localhost:8080
@@ -887,14 +887,14 @@ Content-Length: 20
 <div class="title">curl-request</div>
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/accounts' -i -X DELETE \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njk1NDA5MDYsImV4cCI6MTY2OTU0NDUwNn0.G6HM1grZLvQo7eaM8_12txyXVqlfz-tx6Dp2GzUH2qY'</code></pre>
+    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njk1OTcwNzcsImV4cCI6MTY2OTYwMDY3N30.b-36urCkoxCGm6ZIEfnJoB9a151vXJfCT_Y73cSFTNQ'</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">http-request</div>
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">DELETE /accounts HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njk1NDA5MDYsImV4cCI6MTY2OTU0NDUwNn0.G6HM1grZLvQo7eaM8_12txyXVqlfz-tx6Dp2GzUH2qY
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njk1OTcwNzcsImV4cCI6MTY2OTYwMDY3N30.b-36urCkoxCGm6ZIEfnJoB9a151vXJfCT_Y73cSFTNQ
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -1059,14 +1059,14 @@ Content-Length: 265
 <div class="title">curl-request</div>
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/accounts/login' -i -X GET \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njk1NDA5MDgsImV4cCI6MTY2OTU0NDUwOH0.SynFFvL0cFywlCNoF_aCi763xtU8uemL5mYR9Kuol7U'</code></pre>
+    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njk1OTcwNzksImV4cCI6MTY2OTYwMDY3OX0.EZQVYjQY1yVPcKc6n4-FR6Fiw-DHclXlzuSugmASQWY'</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">http-request</div>
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">GET /accounts/login HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njk1NDA5MDgsImV4cCI6MTY2OTU0NDUwOH0.SynFFvL0cFywlCNoF_aCi763xtU8uemL5mYR9Kuol7U
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njk1OTcwNzksImV4cCI6MTY2OTYwMDY3OX0.EZQVYjQY1yVPcKc6n4-FR6Fiw-DHclXlzuSugmASQWY
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -1160,14 +1160,14 @@ Content-Length: 200
 <div class="title">curl-request</div>
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/accounts/follow/10001?page=1&amp;size=5&amp;sort=createdAt%2Cdesc&amp;status=following' -i -X GET \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njk1NDA5MDcsImV4cCI6MTY2OTU0NDUwN30.1DyWQu-RB_2kMtG-jJSys7ujYpIOXWIWJNvMJ0ZVEW4'</code></pre>
+    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njk1OTcwNzgsImV4cCI6MTY2OTYwMDY3OH0.NETJuOBG8PGvUt2ToYkTyF-Kn-f1cSEPxfbJwEW8ZGY'</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">http-request</div>
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">GET /accounts/follow/10001?page=1&amp;size=5&amp;sort=createdAt%2Cdesc&amp;status=following HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njk1NDA5MDcsImV4cCI6MTY2OTU0NDUwN30.1DyWQu-RB_2kMtG-jJSys7ujYpIOXWIWJNvMJ0ZVEW4
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njk1OTcwNzgsImV4cCI6MTY2OTYwMDY3OH0.NETJuOBG8PGvUt2ToYkTyF-Kn-f1cSEPxfbJwEW8ZGY
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -1477,7 +1477,7 @@ X-Frame-Options: DENY</code></pre>
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/boards' -i -X POST \
     -H 'Content-Type: application/json;charset=UTF-8' \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InVzZXJBQHRlc3QuY29tIiwic3ViIjoiMjAwMDEiLCJpYXQiOjE2Njk1NDA5MDksImV4cCI6MTY2OTU0NDUwOX0.3UgQ_iKfpcSjfBdcKUcexubWg816arAfyvvyd0zj9lo' \
+    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InVzZXJBQHRlc3QuY29tIiwic3ViIjoiMjAwMDEiLCJpYXQiOjE2Njk1OTcwODAsImV4cCI6MTY2OTYwMDY4MH0.lN12Pul26orjfu7hWl_uPO72Mj_b0rc_SGTR7Up-uRQ' \
     -H 'Accept: application/json' \
     -d '{
   "title" : "board title",
@@ -1494,7 +1494,7 @@ X-Frame-Options: DENY</code></pre>
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">POST /boards HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InVzZXJBQHRlc3QuY29tIiwic3ViIjoiMjAwMDEiLCJpYXQiOjE2Njk1NDA5MDksImV4cCI6MTY2OTU0NDUwOX0.3UgQ_iKfpcSjfBdcKUcexubWg816arAfyvvyd0zj9lo
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InVzZXJBQHRlc3QuY29tIiwic3ViIjoiMjAwMDEiLCJpYXQiOjE2Njk1OTcwODAsImV4cCI6MTY2OTYwMDY4MH0.lN12Pul26orjfu7hWl_uPO72Mj_b0rc_SGTR7Up-uRQ
 Accept: application/json
 Content-Length: 280
 Host: localhost:8080
@@ -1629,7 +1629,7 @@ Content-Length: 16
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/boards/31001' -i -X POST \
     -H 'Content-Type: application/json;charset=UTF-8' \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InVzZXJBQHRlc3QuY29tIiwic3ViIjoiMjAwMDEiLCJpYXQiOjE2Njk1NDA5MDksImV4cCI6MTY2OTU0NDUwOX0.3UgQ_iKfpcSjfBdcKUcexubWg816arAfyvvyd0zj9lo' \
+    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InVzZXJBQHRlc3QuY29tIiwic3ViIjoiMjAwMDEiLCJpYXQiOjE2Njk1OTcwODEsImV4cCI6MTY2OTYwMDY4MX0.TbKzEKU5dKg3bPMyfia13WzWv6q8BaROC2I1kxUbpzo' \
     -H 'Accept: application/json' \
     -d '{
   "title" : "modified board title",
@@ -1646,7 +1646,7 @@ Content-Length: 16
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">POST /boards/31001 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InVzZXJBQHRlc3QuY29tIiwic3ViIjoiMjAwMDEiLCJpYXQiOjE2Njk1NDA5MDksImV4cCI6MTY2OTU0NDUwOX0.3UgQ_iKfpcSjfBdcKUcexubWg816arAfyvvyd0zj9lo
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InVzZXJBQHRlc3QuY29tIiwic3ViIjoiMjAwMDEiLCJpYXQiOjE2Njk1OTcwODEsImV4cCI6MTY2OTYwMDY4MX0.TbKzEKU5dKg3bPMyfia13WzWv6q8BaROC2I1kxUbpzo
 Accept: application/json
 Content-Length: 313
 Host: localhost:8080
@@ -1802,14 +1802,14 @@ Content-Length: 20
 <div class="title">curl-request</div>
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/boards/31002' -i -X DELETE \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InVzZXJBQHRlc3QuY29tIiwic3ViIjoiMjAwMDEiLCJpYXQiOjE2Njk1NDA5MDksImV4cCI6MTY2OTU0NDUwOX0.3UgQ_iKfpcSjfBdcKUcexubWg816arAfyvvyd0zj9lo'</code></pre>
+    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InVzZXJBQHRlc3QuY29tIiwic3ViIjoiMjAwMDEiLCJpYXQiOjE2Njk1OTcwODAsImV4cCI6MTY2OTYwMDY4MH0.lN12Pul26orjfu7hWl_uPO72Mj_b0rc_SGTR7Up-uRQ'</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">http-request</div>
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">DELETE /boards/31002 HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InVzZXJBQHRlc3QuY29tIiwic3ViIjoiMjAwMDEiLCJpYXQiOjE2Njk1NDA5MDksImV4cCI6MTY2OTU0NDUwOX0.3UgQ_iKfpcSjfBdcKUcexubWg816arAfyvvyd0zj9lo
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InVzZXJBQHRlc3QuY29tIiwic3ViIjoiMjAwMDEiLCJpYXQiOjE2Njk1OTcwODAsImV4cCI6MTY2OTYwMDY4MH0.lN12Pul26orjfu7hWl_uPO72Mj_b0rc_SGTR7Up-uRQ
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -2010,7 +2010,7 @@ Content-Length: 567
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>createdAt</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">게시글 생성 날짜</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">게시글 생성 시각</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>account</code></p></td>
@@ -2093,6 +2093,11 @@ Host: localhost:8080</code></pre>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>false</code></p></td>
 </tr>
 <tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>lastBoardCreatedAt</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">마지막 게시글 생성 시각</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>false</code></p></td>
+</tr>
+<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>lastBoardViews</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">마지막 게시글 조회수</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>false</code></p></td>
@@ -2118,7 +2123,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 9179
+Content-Length: 10019
 
 {
   "content" : [ {
@@ -2127,6 +2132,7 @@ Content-Length: 9179
     "title" : "testTitle",
     "likeCount" : 1,
     "views" : 121,
+    "createdAt" : "2022-11-14T12:00:21",
     "tags" : [ ],
     "account" : {
       "accountId" : 20003,
@@ -2139,6 +2145,7 @@ Content-Length: 9179
     "title" : "testTitleContainsQuery",
     "likeCount" : 0,
     "views" : 120,
+    "createdAt" : "2022-11-14T12:00:20",
     "tags" : [ "testContainsQuery" ],
     "account" : {
       "accountId" : 20002,
@@ -2151,6 +2158,7 @@ Content-Length: 9179
     "title" : "testTitle",
     "likeCount" : 9,
     "views" : 119,
+    "createdAt" : "2022-11-14T12:00:19",
     "tags" : [ ],
     "account" : {
       "accountId" : 20001,
@@ -2163,6 +2171,7 @@ Content-Length: 9179
     "title" : "testTitleContainsQuery",
     "likeCount" : 8,
     "views" : 118,
+    "createdAt" : "2022-11-14T12:00:18",
     "tags" : [ ],
     "account" : {
       "accountId" : 20003,
@@ -2175,6 +2184,7 @@ Content-Length: 9179
     "title" : "testTitle",
     "likeCount" : 7,
     "views" : 117,
+    "createdAt" : "2022-11-14T12:00:17",
     "tags" : [ ],
     "account" : {
       "accountId" : 20002,
@@ -2187,6 +2197,7 @@ Content-Length: 9179
     "title" : "testTitleContainsQuery",
     "likeCount" : 6,
     "views" : 116,
+    "createdAt" : "2022-11-14T12:00:16",
     "tags" : [ ],
     "account" : {
       "accountId" : 20001,
@@ -2199,6 +2210,7 @@ Content-Length: 9179
     "title" : "testTitle",
     "likeCount" : 5,
     "views" : 115,
+    "createdAt" : "2022-11-14T12:00:15",
     "tags" : [ "testContainsQuery" ],
     "account" : {
       "accountId" : 20003,
@@ -2211,6 +2223,7 @@ Content-Length: 9179
     "title" : "testTitleContainsQuery",
     "likeCount" : 4,
     "views" : 114,
+    "createdAt" : "2022-11-14T12:00:14",
     "tags" : [ ],
     "account" : {
       "accountId" : 20002,
@@ -2223,6 +2236,7 @@ Content-Length: 9179
     "title" : "testTitle",
     "likeCount" : 3,
     "views" : 113,
+    "createdAt" : "2022-11-14T12:00:13",
     "tags" : [ ],
     "account" : {
       "accountId" : 20001,
@@ -2235,6 +2249,7 @@ Content-Length: 9179
     "title" : "testTitleContainsQuery",
     "likeCount" : 2,
     "views" : 112,
+    "createdAt" : "2022-11-14T12:00:12",
     "tags" : [ ],
     "account" : {
       "accountId" : 20003,
@@ -2247,6 +2262,7 @@ Content-Length: 9179
     "title" : "testTitle",
     "likeCount" : 1,
     "views" : 111,
+    "createdAt" : "2022-11-14T12:00:11",
     "tags" : [ ],
     "account" : {
       "accountId" : 20002,
@@ -2259,6 +2275,7 @@ Content-Length: 9179
     "title" : "testTitleContainsQuery",
     "likeCount" : 0,
     "views" : 110,
+    "createdAt" : "2022-11-14T12:00:10",
     "tags" : [ "testContainsQuery" ],
     "account" : {
       "accountId" : 20001,
@@ -2271,6 +2288,7 @@ Content-Length: 9179
     "title" : "testTitle",
     "likeCount" : 9,
     "views" : 109,
+    "createdAt" : "2022-11-14T12:00:09",
     "tags" : [ ],
     "account" : {
       "accountId" : 20003,
@@ -2283,6 +2301,7 @@ Content-Length: 9179
     "title" : "testTitleContainsQuery",
     "likeCount" : 8,
     "views" : 108,
+    "createdAt" : "2022-11-14T12:00:08",
     "tags" : [ ],
     "account" : {
       "accountId" : 20002,
@@ -2295,6 +2314,7 @@ Content-Length: 9179
     "title" : "testTitle",
     "likeCount" : 7,
     "views" : 107,
+    "createdAt" : "2022-11-14T12:00:07",
     "tags" : [ ],
     "account" : {
       "accountId" : 20001,
@@ -2307,6 +2327,7 @@ Content-Length: 9179
     "title" : "testTitleContainsQuery",
     "likeCount" : 6,
     "views" : 106,
+    "createdAt" : "2022-11-14T12:00:06",
     "tags" : [ ],
     "account" : {
       "accountId" : 20003,
@@ -2319,6 +2340,7 @@ Content-Length: 9179
     "title" : "testTitle",
     "likeCount" : 5,
     "views" : 105,
+    "createdAt" : "2022-11-14T12:00:05",
     "tags" : [ "testContainsQuery" ],
     "account" : {
       "accountId" : 20002,
@@ -2331,6 +2353,7 @@ Content-Length: 9179
     "title" : "testTitleContainsQuery",
     "likeCount" : 4,
     "views" : 104,
+    "createdAt" : "2022-11-14T12:00:04",
     "tags" : [ ],
     "account" : {
       "accountId" : 20001,
@@ -2343,6 +2366,7 @@ Content-Length: 9179
     "title" : "testTitle",
     "likeCount" : 3,
     "views" : 103,
+    "createdAt" : "2022-11-14T12:00:03",
     "tags" : [ ],
     "account" : {
       "accountId" : 20003,
@@ -2355,6 +2379,7 @@ Content-Length: 9179
     "title" : "testTitleContainsQuery",
     "likeCount" : 2,
     "views" : 102,
+    "createdAt" : "2022-11-14T12:00:02",
     "tags" : [ ],
     "account" : {
       "accountId" : 20002,
@@ -2413,6 +2438,11 @@ Content-Length: 9179
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].views</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">게시글 조휘수</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].createdAt</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">게시글 생성 시각</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].tags</code></p></td>
@@ -2521,6 +2551,11 @@ Host: localhost:8080</code></pre>
 <td class="tableblock halign-left valign-top"><p class="tableblock">마지막 게시글 Id</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>false</code></p></td>
 </tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>lastBoardCreatedAt</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">마지막 게시글 생성 시각</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>false</code></p></td>
+</tr>
 </tbody>
 </table>
 <div class="listingblock">
@@ -2537,7 +2572,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 3302
+Content-Length: 3596
 
 {
   "content" : [ {
@@ -2546,6 +2581,7 @@ Content-Length: 3302
     "title" : "testTitleContainsQuery",
     "likeCount" : 0,
     "views" : 120,
+    "createdAt" : "2022-11-14T12:00:20",
     "tags" : [ "testContainsQuery" ],
     "account" : {
       "accountId" : 20002,
@@ -2558,6 +2594,7 @@ Content-Length: 3302
     "title" : "testTitle",
     "likeCount" : 7,
     "views" : 117,
+    "createdAt" : "2022-11-14T12:00:17",
     "tags" : [ ],
     "account" : {
       "accountId" : 20002,
@@ -2570,6 +2607,7 @@ Content-Length: 3302
     "title" : "testTitleContainsQuery",
     "likeCount" : 4,
     "views" : 114,
+    "createdAt" : "2022-11-14T12:00:14",
     "tags" : [ ],
     "account" : {
       "accountId" : 20002,
@@ -2582,6 +2620,7 @@ Content-Length: 3302
     "title" : "testTitle",
     "likeCount" : 1,
     "views" : 111,
+    "createdAt" : "2022-11-14T12:00:11",
     "tags" : [ ],
     "account" : {
       "accountId" : 20002,
@@ -2594,6 +2633,7 @@ Content-Length: 3302
     "title" : "testTitleContainsQuery",
     "likeCount" : 8,
     "views" : 108,
+    "createdAt" : "2022-11-14T12:00:08",
     "tags" : [ ],
     "account" : {
       "accountId" : 20002,
@@ -2606,6 +2646,7 @@ Content-Length: 3302
     "title" : "testTitle",
     "likeCount" : 5,
     "views" : 105,
+    "createdAt" : "2022-11-14T12:00:05",
     "tags" : [ "testContainsQuery" ],
     "account" : {
       "accountId" : 20002,
@@ -2618,6 +2659,7 @@ Content-Length: 3302
     "title" : "testTitleContainsQuery",
     "likeCount" : 2,
     "views" : 102,
+    "createdAt" : "2022-11-14T12:00:02",
     "tags" : [ ],
     "account" : {
       "accountId" : 20002,
@@ -2676,6 +2718,11 @@ Content-Length: 3302
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].views</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">게시글 조회수/실제와 차이 있음</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].createdAt</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">게시글 생성 시각</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].tags</code></p></td>
@@ -2781,7 +2828,7 @@ Host: localhost:8080</code></pre>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>lastLikeId</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">마지막 게시글의 likeId</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">마지막 게시글의 like 시각</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>false</code></p></td>
 </tr>
 </tbody>
@@ -2800,16 +2847,17 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 3305
+Content-Length: 3627
 
 {
   "content" : [ {
     "boardId" : 21019,
-    "likeId" : 26001,
     "thumbnail" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
     "title" : "testTitle",
     "likeCount" : 9,
     "tags" : [ ],
+    "likeId" : 26007,
+    "likeCreatedAt" : "2022-11-14T13:00:07",
     "account" : {
       "accountId" : 20001,
       "profile" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
@@ -2817,11 +2865,12 @@ Content-Length: 3305
     }
   }, {
     "boardId" : 21016,
-    "likeId" : 26002,
     "thumbnail" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
     "title" : "testTitleContainsQuery",
     "likeCount" : 6,
     "tags" : [ ],
+    "likeId" : 26006,
+    "likeCreatedAt" : "2022-11-14T13:00:06",
     "account" : {
       "accountId" : 20001,
       "profile" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
@@ -2829,11 +2878,12 @@ Content-Length: 3305
     }
   }, {
     "boardId" : 21013,
-    "likeId" : 26003,
     "thumbnail" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
     "title" : "testTitle",
     "likeCount" : 3,
     "tags" : [ ],
+    "likeId" : 26005,
+    "likeCreatedAt" : "2022-11-14T13:00:05",
     "account" : {
       "accountId" : 20001,
       "profile" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
@@ -2841,11 +2891,12 @@ Content-Length: 3305
     }
   }, {
     "boardId" : 21010,
-    "likeId" : 26004,
     "thumbnail" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
     "title" : "testTitleContainsQuery",
     "likeCount" : 0,
     "tags" : [ "testContainsQuery" ],
+    "likeId" : 26004,
+    "likeCreatedAt" : "2022-11-14T13:00:04",
     "account" : {
       "accountId" : 20001,
       "profile" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
@@ -2853,11 +2904,12 @@ Content-Length: 3305
     }
   }, {
     "boardId" : 21007,
-    "likeId" : 26005,
     "thumbnail" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
     "title" : "testTitle",
     "likeCount" : 7,
     "tags" : [ ],
+    "likeId" : 26003,
+    "likeCreatedAt" : "2022-11-14T13:00:03",
     "account" : {
       "accountId" : 20001,
       "profile" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
@@ -2865,11 +2917,12 @@ Content-Length: 3305
     }
   }, {
     "boardId" : 21004,
-    "likeId" : 26006,
     "thumbnail" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
     "title" : "testTitleContainsQuery",
     "likeCount" : 4,
     "tags" : [ ],
+    "likeId" : 26002,
+    "likeCreatedAt" : "2022-11-14T13:00:02",
     "account" : {
       "accountId" : 20001,
       "profile" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
@@ -2877,11 +2930,12 @@ Content-Length: 3305
     }
   }, {
     "boardId" : 21001,
-    "likeId" : 26007,
     "thumbnail" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
     "title" : "testTitle",
     "likeCount" : 1,
     "tags" : [ "tag1", "tag2" ],
+    "likeId" : 26001,
+    "likeCreatedAt" : "2022-11-14T13:00:01",
     "account" : {
       "accountId" : 20001,
       "profile" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
@@ -2921,11 +2975,6 @@ Content-Length: 3305
 <td class="tableblock halign-left valign-top"><p class="tableblock">게시글 식별자</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].likeId</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">게시글 식별자</p></td>
-</tr>
-<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].thumbnail</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">게시글 썸네일</p></td>
@@ -2944,6 +2993,16 @@ Content-Length: 3305
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].tags</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">게시글 태그</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].likeId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">좋아요 Id</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].likeCreatedAt</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">좋아요 시각</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].account</code></p></td>
@@ -3001,7 +3060,7 @@ Content-Length: 3305
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/comments' -i -X POST \
     -H 'Content-Type: application/json;charset=UTF-8' \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InVzZXJBQHRlc3QuY29tIiwic3ViIjoiMjAwMDEiLCJpYXQiOjE2Njk1NDA5MDksImV4cCI6MTY2OTU0NDUwOX0.3UgQ_iKfpcSjfBdcKUcexubWg816arAfyvvyd0zj9lo' \
+    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InVzZXJBQHRlc3QuY29tIiwic3ViIjoiMjAwMDEiLCJpYXQiOjE2Njk1OTcwODEsImV4cCI6MTY2OTYwMDY4MX0.TbKzEKU5dKg3bPMyfia13WzWv6q8BaROC2I1kxUbpzo' \
     -d '{
   "boardId" : 21001,
   "content" : "testCommentContents"
@@ -3013,7 +3072,7 @@ Content-Length: 3305
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">POST /comments HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InVzZXJBQHRlc3QuY29tIiwic3ViIjoiMjAwMDEiLCJpYXQiOjE2Njk1NDA5MDksImV4cCI6MTY2OTU0NDUwOX0.3UgQ_iKfpcSjfBdcKUcexubWg816arAfyvvyd0zj9lo
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InVzZXJBQHRlc3QuY29tIiwic3ViIjoiMjAwMDEiLCJpYXQiOjE2Njk1OTcwODEsImV4cCI6MTY2OTYwMDY4MX0.TbKzEKU5dKg3bPMyfia13WzWv6q8BaROC2I1kxUbpzo
 Content-Length: 63
 Host: localhost:8080
 
@@ -3095,7 +3154,7 @@ X-Frame-Options: DENY</code></pre>
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/comments/25001' -i -X PATCH \
     -H 'Content-Type: application/json;charset=UTF-8' \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InVzZXJBQHRlc3QuY29tIiwic3ViIjoiMjAwMDEiLCJpYXQiOjE2Njk1NDA5MDksImV4cCI6MTY2OTU0NDUwOX0.3UgQ_iKfpcSjfBdcKUcexubWg816arAfyvvyd0zj9lo' \
+    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InVzZXJBQHRlc3QuY29tIiwic3ViIjoiMjAwMDEiLCJpYXQiOjE2Njk1OTcwODEsImV4cCI6MTY2OTYwMDY4MX0.TbKzEKU5dKg3bPMyfia13WzWv6q8BaROC2I1kxUbpzo' \
     -d '{
   "content" : "modified testContents"
 }'</code></pre>
@@ -3106,7 +3165,7 @@ X-Frame-Options: DENY</code></pre>
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">PATCH /comments/25001 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InVzZXJBQHRlc3QuY29tIiwic3ViIjoiMjAwMDEiLCJpYXQiOjE2Njk1NDA5MDksImV4cCI6MTY2OTU0NDUwOX0.3UgQ_iKfpcSjfBdcKUcexubWg816arAfyvvyd0zj9lo
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InVzZXJBQHRlc3QuY29tIiwic3ViIjoiMjAwMDEiLCJpYXQiOjE2Njk1OTcwODEsImV4cCI6MTY2OTYwMDY4MX0.TbKzEKU5dKg3bPMyfia13WzWv6q8BaROC2I1kxUbpzo
 Content-Length: 43
 Host: localhost:8080
 
@@ -3203,14 +3262,14 @@ X-Frame-Options: DENY</code></pre>
 <div class="title">curl-request</div>
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/comments/35001' -i -X DELETE \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InVzZXJBQHRlc3QuY29tIiwic3ViIjoiMjAwMDEiLCJpYXQiOjE2Njk1NDA5MDksImV4cCI6MTY2OTU0NDUwOX0.3UgQ_iKfpcSjfBdcKUcexubWg816arAfyvvyd0zj9lo'</code></pre>
+    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InVzZXJBQHRlc3QuY29tIiwic3ViIjoiMjAwMDEiLCJpYXQiOjE2Njk1OTcwODEsImV4cCI6MTY2OTYwMDY4MX0.TbKzEKU5dKg3bPMyfia13WzWv6q8BaROC2I1kxUbpzo'</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">http-request</div>
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">DELETE /comments/35001 HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InVzZXJBQHRlc3QuY29tIiwic3ViIjoiMjAwMDEiLCJpYXQiOjE2Njk1NDA5MDksImV4cCI6MTY2OTU0NDUwOX0.3UgQ_iKfpcSjfBdcKUcexubWg816arAfyvvyd0zj9lo
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InVzZXJBQHRlc3QuY29tIiwic3ViIjoiMjAwMDEiLCJpYXQiOjE2Njk1OTcwODEsImV4cCI6MTY2OTYwMDY4MX0.TbKzEKU5dKg3bPMyfia13WzWv6q8BaROC2I1kxUbpzo
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -3338,6 +3397,11 @@ Host: localhost:8080</code></pre>
 <td class="tableblock halign-left valign-top"><p class="tableblock">마지막 댓글 Id</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>false</code></p></td>
 </tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>lastCommentCreatedAt</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">마지막 댓글 생성 시각</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>false</code></p></td>
+</tr>
 </tbody>
 </table>
 <div class="listingblock">
@@ -3367,15 +3431,6 @@ Content-Length: 1657
       "nickname" : "userA"
     }
   }, {
-    "commentId" : 25005,
-    "content" : "testComment",
-    "createdAt" : "2022-10-14T14:00:01",
-    "account" : {
-      "accountId" : 20002,
-      "profile" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
-      "nickname" : "userB"
-    }
-  }, {
     "commentId" : 25006,
     "content" : "testComment",
     "createdAt" : "2022-10-14T14:00:01",
@@ -3385,13 +3440,22 @@ Content-Length: 1657
       "nickname" : "userC"
     }
   }, {
-    "commentId" : 25001,
+    "commentId" : 25005,
     "content" : "testComment",
     "createdAt" : "2022-10-14T14:00:01",
     "account" : {
-      "accountId" : 20001,
+      "accountId" : 20002,
       "profile" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
-      "nickname" : "userA"
+      "nickname" : "userB"
+    }
+  }, {
+    "commentId" : 25003,
+    "content" : "testComment",
+    "createdAt" : "2022-10-14T14:00:01",
+    "account" : {
+      "accountId" : 20003,
+      "profile" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
+      "nickname" : "userC"
     }
   }, {
     "commentId" : 25002,
@@ -3500,14 +3564,14 @@ Content-Length: 1657
 <div class="title">curl-request</div>
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/follows/10002' -i -X POST \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njk1NDA5MTAsImV4cCI6MTY2OTU0NDUxMH0.9bduoiFRBNQM0OquCW9YUJksghTNLq8v-nbd3YTuHBk'</code></pre>
+    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njk1OTcwODEsImV4cCI6MTY2OTYwMDY4MX0.Z73pmSnpTv_VFx7sba4TlGyZczj6R5z4fhOkeQ-gbkM'</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">http-request</div>
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">POST /follows/10002 HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njk1NDA5MTAsImV4cCI6MTY2OTU0NDUxMH0.9bduoiFRBNQM0OquCW9YUJksghTNLq8v-nbd3YTuHBk
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njk1OTcwODEsImV4cCI6MTY2OTYwMDY4MX0.Z73pmSnpTv_VFx7sba4TlGyZczj6R5z4fhOkeQ-gbkM
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -3605,14 +3669,14 @@ Content-Length: 28
 <div class="title">curl-request</div>
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/follows/10002' -i -X GET \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njk1NDA5MTAsImV4cCI6MTY2OTU0NDUxMH0.9bduoiFRBNQM0OquCW9YUJksghTNLq8v-nbd3YTuHBk'</code></pre>
+    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njk1OTcwODEsImV4cCI6MTY2OTYwMDY4MX0.Z73pmSnpTv_VFx7sba4TlGyZczj6R5z4fhOkeQ-gbkM'</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">http-request</div>
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">GET /follows/10002 HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njk1NDA5MTAsImV4cCI6MTY2OTU0NDUxMH0.9bduoiFRBNQM0OquCW9YUJksghTNLq8v-nbd3YTuHBk
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njk1OTcwODEsImV4cCI6MTY2OTYwMDY4MX0.Z73pmSnpTv_VFx7sba4TlGyZczj6R5z4fhOkeQ-gbkM
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -3716,14 +3780,14 @@ Content-Length: 23
 <div class="title">curl-request</div>
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/likes/12002' -i -X POST \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njk1NDA5MTAsImV4cCI6MTY2OTU0NDUxMH0.9bduoiFRBNQM0OquCW9YUJksghTNLq8v-nbd3YTuHBk'</code></pre>
+    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njk1OTcwODIsImV4cCI6MTY2OTYwMDY4Mn0.mK9fcIR0r4HKEbySj9x5Y70IWVYEEnn_UQTSAWMKKOU'</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">http-request</div>
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">POST /likes/12002 HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njk1NDA5MTAsImV4cCI6MTY2OTU0NDUxMH0.9bduoiFRBNQM0OquCW9YUJksghTNLq8v-nbd3YTuHBk
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njk1OTcwODIsImV4cCI6MTY2OTYwMDY4Mn0.mK9fcIR0r4HKEbySj9x5Y70IWVYEEnn_UQTSAWMKKOU
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -3821,14 +3885,14 @@ Content-Length: 28
 <div class="title">curl-request</div>
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/likes/12002' -i -X GET \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njk1NDA5MTAsImV4cCI6MTY2OTU0NDUxMH0.9bduoiFRBNQM0OquCW9YUJksghTNLq8v-nbd3YTuHBk'</code></pre>
+    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njk1OTcwODIsImV4cCI6MTY2OTYwMDY4Mn0.mK9fcIR0r4HKEbySj9x5Y70IWVYEEnn_UQTSAWMKKOU'</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">http-request</div>
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">GET /likes/12002 HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njk1NDA5MTAsImV4cCI6MTY2OTU0NDUxMH0.9bduoiFRBNQM0OquCW9YUJksghTNLq8v-nbd3YTuHBk
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njk1OTcwODIsImV4cCI6MTY2OTYwMDY4Mn0.mK9fcIR0r4HKEbySj9x5Y70IWVYEEnn_UQTSAWMKKOU
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -3933,7 +3997,7 @@ Content-Length: 22
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/image-files' -i -X POST \
     -H 'Content-Type: multipart/form-data;charset=UTF-8' \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njk1NDA5MTAsImV4cCI6MTY2OTU0NDUxMH0.9bduoiFRBNQM0OquCW9YUJksghTNLq8v-nbd3YTuHBk' \
+    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njk1OTcwODIsImV4cCI6MTY2OTYwMDY4Mn0.mK9fcIR0r4HKEbySj9x5Y70IWVYEEnn_UQTSAWMKKOU' \
     -F 'images=@image1.jpeg;type=image/jpeg' \
     -F 'images=@image2.jpeg;type=image/jpeg' \
     -F 'images=@image3.jpeg;type=image/jpeg'</code></pre>
@@ -3944,7 +4008,7 @@ Content-Length: 22
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">POST /image-files HTTP/1.1
 Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njk1NDA5MTAsImV4cCI6MTY2OTU0NDUxMH0.9bduoiFRBNQM0OquCW9YUJksghTNLq8v-nbd3YTuHBk
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njk1OTcwODIsImV4cCI6MTY2OTYwMDY4Mn0.mK9fcIR0r4HKEbySj9x5Y70IWVYEEnn_UQTSAWMKKOU
 Host: localhost:8080
 
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
@@ -4026,7 +4090,7 @@ X-Frame-Options: DENY
 Content-Length: 262
 
 {
-  "imagePaths" : [ "http://localhost:8080/image-files/38c26929-0deb-4aed-8ec9-2dec501ea835.jpeg", "http://localhost:8080/image-files/2709a991-3712-4dbf-90ba-4885f11d1683.jpeg", "http://localhost:8080/image-files/6b487f8d-e509-402a-a3b0-1aaefb86df47.jpeg" ]
+  "imagePaths" : [ "http://localhost:8080/image-files/e8809db1-89d1-4424-9e32-4ae6b1d4d177.jpeg", "http://localhost:8080/image-files/c4af013f-fd3e-43e3-9202-707caaf7cffb.jpeg", "http://localhost:8080/image-files/de3bd923-c60e-40e8-9994-cee2fdd82791.jpeg" ]
 }</code></pre>
 </div>
 </div>

--- a/back/src/main/resources/static/docs/index.html
+++ b/back/src/main/resources/static/docs/index.html
@@ -528,7 +528,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <pre class="prettyprint highlight nowrap"><code data-lang="http">POST /login HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Accept: application/json
-Content-Length: 59
+Content-Length: 62
 Host: localhost:8080
 
 {
@@ -571,7 +571,7 @@ Host: localhost:8080
 Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjkzNzM0MjQsImV4cCI6MTY2OTM3NzAyNH0.t4KBF1teJ6nRe-SiZoiv2dGGkrh2f1xKtiCi_au9e-4
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njk1NDA5MDgsImV4cCI6MTY2OTU0NDUwOH0.SynFFvL0cFywlCNoF_aCi763xtU8uemL5mYR9Kuol7U
 X-Content-Type-Options: nosniff
 X-XSS-Protection: 1; mode=block
 Cache-Control: no-cache, no-store, max-age=0, must-revalidate
@@ -713,7 +713,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 14
+Content-Length: 16
 
 {
   "id" : 1
@@ -750,7 +750,7 @@ Content-Length: 14
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/accounts/modify' -i -X POST \
     -H 'Content-Type: application/json;charset=UTF-8' \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjkzNzM0MjMsImV4cCI6MTY2OTM3NzAyM30.p04v11uRjuaYOt9YL-VxmFI-qHiXjCYzcuJf4SciBJQ' \
+    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njk1NDA5MDcsImV4cCI6MTY2OTU0NDUwN30.1DyWQu-RB_2kMtG-jJSys7ujYpIOXWIWJNvMJ0ZVEW4' \
     -H 'Accept: application/json' \
     -d '{
   "password" : "123456789",
@@ -765,9 +765,9 @@ Content-Length: 14
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">POST /accounts/modify HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjkzNzM0MjMsImV4cCI6MTY2OTM3NzAyM30.p04v11uRjuaYOt9YL-VxmFI-qHiXjCYzcuJf4SciBJQ
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njk1NDA5MDcsImV4cCI6MTY2OTU0NDUwN30.1DyWQu-RB_2kMtG-jJSys7ujYpIOXWIWJNvMJ0ZVEW4
 Accept: application/json
-Content-Length: 125
+Content-Length: 130
 Host: localhost:8080
 
 {
@@ -851,7 +851,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 18
+Content-Length: 20
 
 {
   "id" : 10001
@@ -887,14 +887,14 @@ Content-Length: 18
 <div class="title">curl-request</div>
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/accounts' -i -X DELETE \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjkzNzM0MjMsImV4cCI6MTY2OTM3NzAyM30.p04v11uRjuaYOt9YL-VxmFI-qHiXjCYzcuJf4SciBJQ'</code></pre>
+    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njk1NDA5MDYsImV4cCI6MTY2OTU0NDUwNn0.G6HM1grZLvQo7eaM8_12txyXVqlfz-tx6Dp2GzUH2qY'</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">http-request</div>
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">DELETE /accounts HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjkzNzM0MjMsImV4cCI6MTY2OTM3NzAyM30.p04v11uRjuaYOt9YL-VxmFI-qHiXjCYzcuJf4SciBJQ
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njk1NDA5MDYsImV4cCI6MTY2OTU0NDUwNn0.G6HM1grZLvQo7eaM8_12txyXVqlfz-tx6Dp2GzUH2qY
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -987,7 +987,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 257
+Content-Length: 265
 
 {
   "id" : 10001,
@@ -1059,14 +1059,14 @@ Content-Length: 257
 <div class="title">curl-request</div>
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/accounts/login' -i -X GET \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjkzNzM0MjMsImV4cCI6MTY2OTM3NzAyM30.p04v11uRjuaYOt9YL-VxmFI-qHiXjCYzcuJf4SciBJQ'</code></pre>
+    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njk1NDA5MDgsImV4cCI6MTY2OTU0NDUwOH0.SynFFvL0cFywlCNoF_aCi763xtU8uemL5mYR9Kuol7U'</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">http-request</div>
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">GET /accounts/login HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjkzNzM0MjMsImV4cCI6MTY2OTM3NzAyM30.p04v11uRjuaYOt9YL-VxmFI-qHiXjCYzcuJf4SciBJQ
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njk1NDA5MDgsImV4cCI6MTY2OTU0NDUwOH0.SynFFvL0cFywlCNoF_aCi763xtU8uemL5mYR9Kuol7U
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -1106,7 +1106,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 195
+Content-Length: 200
 
 {
   "id" : 10001,
@@ -1160,14 +1160,14 @@ Content-Length: 195
 <div class="title">curl-request</div>
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/accounts/follow/10001?page=1&amp;size=5&amp;sort=createdAt%2Cdesc&amp;status=following' -i -X GET \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjkzNzM0MjMsImV4cCI6MTY2OTM3NzAyM30.p04v11uRjuaYOt9YL-VxmFI-qHiXjCYzcuJf4SciBJQ'</code></pre>
+    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njk1NDA5MDcsImV4cCI6MTY2OTU0NDUwN30.1DyWQu-RB_2kMtG-jJSys7ujYpIOXWIWJNvMJ0ZVEW4'</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">http-request</div>
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">GET /accounts/follow/10001?page=1&amp;size=5&amp;sort=createdAt%2Cdesc&amp;status=following HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjkzNzM0MjMsImV4cCI6MTY2OTM3NzAyM30.p04v11uRjuaYOt9YL-VxmFI-qHiXjCYzcuJf4SciBJQ
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njk1NDA5MDcsImV4cCI6MTY2OTU0NDUwN30.1DyWQu-RB_2kMtG-jJSys7ujYpIOXWIWJNvMJ0ZVEW4
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -1266,7 +1266,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 963
+Content-Length: 993
 
 {
   "content" : [ {
@@ -1418,7 +1418,7 @@ Content-Length: 963
 <pre class="prettyprint highlight nowrap"><code data-lang="http">POST /accounts/tempPassword/email HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Accept: application/json
-Content-Length: 32
+Content-Length: 34
 Host: localhost:8080
 
 {
@@ -1477,7 +1477,7 @@ X-Frame-Options: DENY</code></pre>
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/boards' -i -X POST \
     -H 'Content-Type: application/json;charset=UTF-8' \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InVzZXJBQHRlc3QuY29tIiwic3ViIjoiMjAwMDEiLCJpYXQiOjE2NjkzNzM0MjQsImV4cCI6MTY2OTM3NzAyNH0.LwP17o2d0dk13pWqBDrsa6kkptMkrDT1L2yh7kjGA_E' \
+    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InVzZXJBQHRlc3QuY29tIiwic3ViIjoiMjAwMDEiLCJpYXQiOjE2Njk1NDA5MDksImV4cCI6MTY2OTU0NDUwOX0.3UgQ_iKfpcSjfBdcKUcexubWg816arAfyvvyd0zj9lo' \
     -H 'Accept: application/json' \
     -d '{
   "title" : "board title",
@@ -1494,9 +1494,9 @@ X-Frame-Options: DENY</code></pre>
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">POST /boards HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InVzZXJBQHRlc3QuY29tIiwic3ViIjoiMjAwMDEiLCJpYXQiOjE2NjkzNzM0MjQsImV4cCI6MTY2OTM3NzAyNH0.LwP17o2d0dk13pWqBDrsa6kkptMkrDT1L2yh7kjGA_E
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InVzZXJBQHRlc3QuY29tIiwic3ViIjoiMjAwMDEiLCJpYXQiOjE2Njk1NDA5MDksImV4cCI6MTY2OTU0NDUwOX0.3UgQ_iKfpcSjfBdcKUcexubWg816arAfyvvyd0zj9lo
 Accept: application/json
-Content-Length: 273
+Content-Length: 280
 Host: localhost:8080
 
 {
@@ -1592,7 +1592,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 14
+Content-Length: 16
 
 {
   "id" : 3
@@ -1629,7 +1629,7 @@ Content-Length: 14
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/boards/31001' -i -X POST \
     -H 'Content-Type: application/json;charset=UTF-8' \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InVzZXJBQHRlc3QuY29tIiwic3ViIjoiMjAwMDEiLCJpYXQiOjE2NjkzNzM0MjQsImV4cCI6MTY2OTM3NzAyNH0.LwP17o2d0dk13pWqBDrsa6kkptMkrDT1L2yh7kjGA_E' \
+    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InVzZXJBQHRlc3QuY29tIiwic3ViIjoiMjAwMDEiLCJpYXQiOjE2Njk1NDA5MDksImV4cCI6MTY2OTU0NDUwOX0.3UgQ_iKfpcSjfBdcKUcexubWg816arAfyvvyd0zj9lo' \
     -H 'Accept: application/json' \
     -d '{
   "title" : "modified board title",
@@ -1646,9 +1646,9 @@ Content-Length: 14
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">POST /boards/31001 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InVzZXJBQHRlc3QuY29tIiwic3ViIjoiMjAwMDEiLCJpYXQiOjE2NjkzNzM0MjQsImV4cCI6MTY2OTM3NzAyNH0.LwP17o2d0dk13pWqBDrsa6kkptMkrDT1L2yh7kjGA_E
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InVzZXJBQHRlc3QuY29tIiwic3ViIjoiMjAwMDEiLCJpYXQiOjE2Njk1NDA5MDksImV4cCI6MTY2OTU0NDUwOX0.3UgQ_iKfpcSjfBdcKUcexubWg816arAfyvvyd0zj9lo
 Accept: application/json
-Content-Length: 306
+Content-Length: 313
 Host: localhost:8080
 
 {
@@ -1766,7 +1766,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 18
+Content-Length: 20
 
 {
   "id" : 31001
@@ -1802,14 +1802,14 @@ Content-Length: 18
 <div class="title">curl-request</div>
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/boards/31002' -i -X DELETE \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InVzZXJBQHRlc3QuY29tIiwic3ViIjoiMjAwMDEiLCJpYXQiOjE2NjkzNzM0MjQsImV4cCI6MTY2OTM3NzAyNH0.LwP17o2d0dk13pWqBDrsa6kkptMkrDT1L2yh7kjGA_E'</code></pre>
+    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InVzZXJBQHRlc3QuY29tIiwic3ViIjoiMjAwMDEiLCJpYXQiOjE2Njk1NDA5MDksImV4cCI6MTY2OTU0NDUwOX0.3UgQ_iKfpcSjfBdcKUcexubWg816arAfyvvyd0zj9lo'</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">http-request</div>
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">DELETE /boards/31002 HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InVzZXJBQHRlc3QuY29tIiwic3ViIjoiMjAwMDEiLCJpYXQiOjE2NjkzNzM0MjQsImV4cCI6MTY2OTM3NzAyNH0.LwP17o2d0dk13pWqBDrsa6kkptMkrDT1L2yh7kjGA_E
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InVzZXJBQHRlc3QuY29tIiwic3ViIjoiMjAwMDEiLCJpYXQiOjE2Njk1NDA5MDksImV4cCI6MTY2OTU0NDUwOX0.3UgQ_iKfpcSjfBdcKUcexubWg816arAfyvvyd0zj9lo
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -1926,7 +1926,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 551
+Content-Length: 567
 
 {
   "boardId" : 21001,
@@ -2040,14 +2040,14 @@ Content-Length: 551
 <div class="listingblock">
 <div class="title">curl-request</div>
 <div class="content">
-<pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/boards?query=&amp;category=&amp;page=1&amp;size=20&amp;sort=createdAt%2CDESC&amp;query=&amp;category=' -i -X GET \
+<pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/boards' -i -X GET \
     -H 'Accept: application/json'</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">http-request</div>
 <div class="content">
-<pre class="prettyprint highlight nowrap"><code data-lang="http">GET /boards?query=&amp;category=&amp;page=1&amp;size=20&amp;sort=createdAt%2CDESC&amp;query=&amp;category= HTTP/1.1
+<pre class="prettyprint highlight nowrap"><code data-lang="http">GET /boards HTTP/1.1
 Accept: application/json
 Host: localhost:8080</code></pre>
 </div>
@@ -2078,11 +2078,6 @@ Host: localhost:8080</code></pre>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>false</code></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>page</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">페이지</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>false</code></p></td>
-</tr>
-<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>size</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">페이지 사이즈</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>false</code></p></td>
@@ -2090,6 +2085,21 @@ Host: localhost:8080</code></pre>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>sort</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">정렬 기준</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>false</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>lastBoardId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">마지막 게시글 Id</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>false</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>lastBoardViews</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">마지막 게시글 조회수</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>false</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>lastBoardLikeCount</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">마지막 게시글 추천수</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>false</code></p></td>
 </tr>
 </tbody>
@@ -2108,7 +2118,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 8553
+Content-Length: 9179
 
 {
   "content" : [ {
@@ -2116,6 +2126,7 @@ Content-Length: 8553
     "thumbnail" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
     "title" : "testTitle",
     "likeCount" : 1,
+    "views" : 121,
     "tags" : [ ],
     "account" : {
       "accountId" : 20003,
@@ -2127,6 +2138,7 @@ Content-Length: 8553
     "thumbnail" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
     "title" : "testTitleContainsQuery",
     "likeCount" : 0,
+    "views" : 120,
     "tags" : [ "testContainsQuery" ],
     "account" : {
       "accountId" : 20002,
@@ -2138,6 +2150,7 @@ Content-Length: 8553
     "thumbnail" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
     "title" : "testTitle",
     "likeCount" : 9,
+    "views" : 119,
     "tags" : [ ],
     "account" : {
       "accountId" : 20001,
@@ -2149,6 +2162,7 @@ Content-Length: 8553
     "thumbnail" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
     "title" : "testTitleContainsQuery",
     "likeCount" : 8,
+    "views" : 118,
     "tags" : [ ],
     "account" : {
       "accountId" : 20003,
@@ -2160,6 +2174,7 @@ Content-Length: 8553
     "thumbnail" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
     "title" : "testTitle",
     "likeCount" : 7,
+    "views" : 117,
     "tags" : [ ],
     "account" : {
       "accountId" : 20002,
@@ -2171,6 +2186,7 @@ Content-Length: 8553
     "thumbnail" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
     "title" : "testTitleContainsQuery",
     "likeCount" : 6,
+    "views" : 116,
     "tags" : [ ],
     "account" : {
       "accountId" : 20001,
@@ -2182,6 +2198,7 @@ Content-Length: 8553
     "thumbnail" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
     "title" : "testTitle",
     "likeCount" : 5,
+    "views" : 115,
     "tags" : [ "testContainsQuery" ],
     "account" : {
       "accountId" : 20003,
@@ -2193,6 +2210,7 @@ Content-Length: 8553
     "thumbnail" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
     "title" : "testTitleContainsQuery",
     "likeCount" : 4,
+    "views" : 114,
     "tags" : [ ],
     "account" : {
       "accountId" : 20002,
@@ -2204,6 +2222,7 @@ Content-Length: 8553
     "thumbnail" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
     "title" : "testTitle",
     "likeCount" : 3,
+    "views" : 113,
     "tags" : [ ],
     "account" : {
       "accountId" : 20001,
@@ -2215,6 +2234,7 @@ Content-Length: 8553
     "thumbnail" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
     "title" : "testTitleContainsQuery",
     "likeCount" : 2,
+    "views" : 112,
     "tags" : [ ],
     "account" : {
       "accountId" : 20003,
@@ -2226,6 +2246,7 @@ Content-Length: 8553
     "thumbnail" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
     "title" : "testTitle",
     "likeCount" : 1,
+    "views" : 111,
     "tags" : [ ],
     "account" : {
       "accountId" : 20002,
@@ -2237,6 +2258,7 @@ Content-Length: 8553
     "thumbnail" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
     "title" : "testTitleContainsQuery",
     "likeCount" : 0,
+    "views" : 110,
     "tags" : [ "testContainsQuery" ],
     "account" : {
       "accountId" : 20001,
@@ -2248,6 +2270,7 @@ Content-Length: 8553
     "thumbnail" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
     "title" : "testTitle",
     "likeCount" : 9,
+    "views" : 109,
     "tags" : [ ],
     "account" : {
       "accountId" : 20003,
@@ -2259,6 +2282,7 @@ Content-Length: 8553
     "thumbnail" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
     "title" : "testTitleContainsQuery",
     "likeCount" : 8,
+    "views" : 108,
     "tags" : [ ],
     "account" : {
       "accountId" : 20002,
@@ -2270,6 +2294,7 @@ Content-Length: 8553
     "thumbnail" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
     "title" : "testTitle",
     "likeCount" : 7,
+    "views" : 107,
     "tags" : [ ],
     "account" : {
       "accountId" : 20001,
@@ -2281,6 +2306,7 @@ Content-Length: 8553
     "thumbnail" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
     "title" : "testTitleContainsQuery",
     "likeCount" : 6,
+    "views" : 106,
     "tags" : [ ],
     "account" : {
       "accountId" : 20003,
@@ -2292,6 +2318,7 @@ Content-Length: 8553
     "thumbnail" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
     "title" : "testTitle",
     "likeCount" : 5,
+    "views" : 105,
     "tags" : [ "testContainsQuery" ],
     "account" : {
       "accountId" : 20002,
@@ -2303,6 +2330,7 @@ Content-Length: 8553
     "thumbnail" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
     "title" : "testTitleContainsQuery",
     "likeCount" : 4,
+    "views" : 104,
     "tags" : [ ],
     "account" : {
       "accountId" : 20001,
@@ -2314,6 +2342,7 @@ Content-Length: 8553
     "thumbnail" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
     "title" : "testTitle",
     "likeCount" : 3,
+    "views" : 103,
     "tags" : [ ],
     "account" : {
       "accountId" : 20003,
@@ -2325,6 +2354,7 @@ Content-Length: 8553
     "thumbnail" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
     "title" : "testTitleContainsQuery",
     "likeCount" : 2,
+    "views" : 102,
     "tags" : [ ],
     "account" : {
       "accountId" : 20002,
@@ -2378,6 +2408,11 @@ Content-Length: 8553
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].likeCount</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">게시글 좋아요 수</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].views</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">게시글 조휘수</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].tags</code></p></td>
@@ -2466,6 +2501,28 @@ Host: localhost:8080</code></pre>
 </tr>
 </tbody>
 </table>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 32. request-parameters</caption>
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+<th class="tableblock halign-left valign-top">Required</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>lastBoardId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">마지막 게시글 Id</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>false</code></p></td>
+</tr>
+</tbody>
+</table>
 <div class="listingblock">
 <div class="title">http-response</div>
 <div class="content">
@@ -2480,7 +2537,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 3079
+Content-Length: 3302
 
 {
   "content" : [ {
@@ -2488,6 +2545,7 @@ Content-Length: 3079
     "thumbnail" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
     "title" : "testTitleContainsQuery",
     "likeCount" : 0,
+    "views" : 120,
     "tags" : [ "testContainsQuery" ],
     "account" : {
       "accountId" : 20002,
@@ -2499,6 +2557,7 @@ Content-Length: 3079
     "thumbnail" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
     "title" : "testTitle",
     "likeCount" : 7,
+    "views" : 117,
     "tags" : [ ],
     "account" : {
       "accountId" : 20002,
@@ -2510,6 +2569,7 @@ Content-Length: 3079
     "thumbnail" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
     "title" : "testTitleContainsQuery",
     "likeCount" : 4,
+    "views" : 114,
     "tags" : [ ],
     "account" : {
       "accountId" : 20002,
@@ -2521,6 +2581,7 @@ Content-Length: 3079
     "thumbnail" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
     "title" : "testTitle",
     "likeCount" : 1,
+    "views" : 111,
     "tags" : [ ],
     "account" : {
       "accountId" : 20002,
@@ -2532,6 +2593,7 @@ Content-Length: 3079
     "thumbnail" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
     "title" : "testTitleContainsQuery",
     "likeCount" : 8,
+    "views" : 108,
     "tags" : [ ],
     "account" : {
       "accountId" : 20002,
@@ -2543,6 +2605,7 @@ Content-Length: 3079
     "thumbnail" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
     "title" : "testTitle",
     "likeCount" : 5,
+    "views" : 105,
     "tags" : [ "testContainsQuery" ],
     "account" : {
       "accountId" : 20002,
@@ -2554,6 +2617,7 @@ Content-Length: 3079
     "thumbnail" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
     "title" : "testTitleContainsQuery",
     "likeCount" : 2,
+    "views" : 102,
     "tags" : [ ],
     "account" : {
       "accountId" : 20002,
@@ -2569,7 +2633,7 @@ Content-Length: 3079
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 32. response-fields</caption>
+<caption class="title">Table 33. response-fields</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -2607,6 +2671,11 @@ Content-Length: 3079
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].likeCount</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">게시글 좋아요 수</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].views</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">게시글 조회수/실제와 차이 있음</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].tags</code></p></td>
@@ -2674,7 +2743,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 33. /boards/like/account/{accountId}</caption>
+<caption class="title">Table 34. /boards/like/account/{accountId}</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -2695,6 +2764,28 @@ Host: localhost:8080</code></pre>
 </tr>
 </tbody>
 </table>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 35. request-parameters</caption>
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+<th class="tableblock halign-left valign-top">Required</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>lastLikeId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">마지막 게시글의 likeId</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>false</code></p></td>
+</tr>
+</tbody>
+</table>
 <div class="listingblock">
 <div class="title">http-response</div>
 <div class="content">
@@ -2709,11 +2800,12 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 3061
+Content-Length: 3305
 
 {
   "content" : [ {
     "boardId" : 21019,
+    "likeId" : 26001,
     "thumbnail" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
     "title" : "testTitle",
     "likeCount" : 9,
@@ -2725,6 +2817,7 @@ Content-Length: 3061
     }
   }, {
     "boardId" : 21016,
+    "likeId" : 26002,
     "thumbnail" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
     "title" : "testTitleContainsQuery",
     "likeCount" : 6,
@@ -2736,6 +2829,7 @@ Content-Length: 3061
     }
   }, {
     "boardId" : 21013,
+    "likeId" : 26003,
     "thumbnail" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
     "title" : "testTitle",
     "likeCount" : 3,
@@ -2747,6 +2841,7 @@ Content-Length: 3061
     }
   }, {
     "boardId" : 21010,
+    "likeId" : 26004,
     "thumbnail" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
     "title" : "testTitleContainsQuery",
     "likeCount" : 0,
@@ -2758,6 +2853,7 @@ Content-Length: 3061
     }
   }, {
     "boardId" : 21007,
+    "likeId" : 26005,
     "thumbnail" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
     "title" : "testTitle",
     "likeCount" : 7,
@@ -2769,6 +2865,7 @@ Content-Length: 3061
     }
   }, {
     "boardId" : 21004,
+    "likeId" : 26006,
     "thumbnail" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
     "title" : "testTitleContainsQuery",
     "likeCount" : 4,
@@ -2780,6 +2877,7 @@ Content-Length: 3061
     }
   }, {
     "boardId" : 21001,
+    "likeId" : 26007,
     "thumbnail" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
     "title" : "testTitle",
     "likeCount" : 1,
@@ -2798,7 +2896,7 @@ Content-Length: 3061
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 34. response-fields</caption>
+<caption class="title">Table 36. response-fields</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -2819,6 +2917,11 @@ Content-Length: 3061
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].boardId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">게시글 식별자</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content[].likeId</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">게시글 식별자</p></td>
 </tr>
@@ -2898,7 +3001,7 @@ Content-Length: 3061
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/comments' -i -X POST \
     -H 'Content-Type: application/json;charset=UTF-8' \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InVzZXJBQHRlc3QuY29tIiwic3ViIjoiMjAwMDEiLCJpYXQiOjE2NjkzNzM0MjQsImV4cCI6MTY2OTM3NzAyNH0.LwP17o2d0dk13pWqBDrsa6kkptMkrDT1L2yh7kjGA_E' \
+    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InVzZXJBQHRlc3QuY29tIiwic3ViIjoiMjAwMDEiLCJpYXQiOjE2Njk1NDA5MDksImV4cCI6MTY2OTU0NDUwOX0.3UgQ_iKfpcSjfBdcKUcexubWg816arAfyvvyd0zj9lo' \
     -d '{
   "boardId" : 21001,
   "content" : "testCommentContents"
@@ -2910,8 +3013,8 @@ Content-Length: 3061
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">POST /comments HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InVzZXJBQHRlc3QuY29tIiwic3ViIjoiMjAwMDEiLCJpYXQiOjE2NjkzNzM0MjQsImV4cCI6MTY2OTM3NzAyNH0.LwP17o2d0dk13pWqBDrsa6kkptMkrDT1L2yh7kjGA_E
-Content-Length: 60
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InVzZXJBQHRlc3QuY29tIiwic3ViIjoiMjAwMDEiLCJpYXQiOjE2Njk1NDA5MDksImV4cCI6MTY2OTU0NDUwOX0.3UgQ_iKfpcSjfBdcKUcexubWg816arAfyvvyd0zj9lo
+Content-Length: 63
 Host: localhost:8080
 
 {
@@ -2921,7 +3024,7 @@ Host: localhost:8080
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 35. request-fields</caption>
+<caption class="title">Table 37. request-fields</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -2948,7 +3051,7 @@ Host: localhost:8080
 </tbody>
 </table>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 36. request-headers</caption>
+<caption class="title">Table 38. request-headers</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -2992,7 +3095,7 @@ X-Frame-Options: DENY</code></pre>
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/comments/25001' -i -X PATCH \
     -H 'Content-Type: application/json;charset=UTF-8' \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InVzZXJBQHRlc3QuY29tIiwic3ViIjoiMjAwMDEiLCJpYXQiOjE2NjkzNzM0MjQsImV4cCI6MTY2OTM3NzAyNH0.LwP17o2d0dk13pWqBDrsa6kkptMkrDT1L2yh7kjGA_E' \
+    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InVzZXJBQHRlc3QuY29tIiwic3ViIjoiMjAwMDEiLCJpYXQiOjE2Njk1NDA5MDksImV4cCI6MTY2OTU0NDUwOX0.3UgQ_iKfpcSjfBdcKUcexubWg816arAfyvvyd0zj9lo' \
     -d '{
   "content" : "modified testContents"
 }'</code></pre>
@@ -3003,8 +3106,8 @@ X-Frame-Options: DENY</code></pre>
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">PATCH /comments/25001 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InVzZXJBQHRlc3QuY29tIiwic3ViIjoiMjAwMDEiLCJpYXQiOjE2NjkzNzM0MjQsImV4cCI6MTY2OTM3NzAyNH0.LwP17o2d0dk13pWqBDrsa6kkptMkrDT1L2yh7kjGA_E
-Content-Length: 41
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InVzZXJBQHRlc3QuY29tIiwic3ViIjoiMjAwMDEiLCJpYXQiOjE2Njk1NDA5MDksImV4cCI6MTY2OTU0NDUwOX0.3UgQ_iKfpcSjfBdcKUcexubWg816arAfyvvyd0zj9lo
+Content-Length: 43
 Host: localhost:8080
 
 {
@@ -3013,7 +3116,7 @@ Host: localhost:8080
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 37. /comments/{commentId}</caption>
+<caption class="title">Table 39. /comments/{commentId}</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -3035,7 +3138,7 @@ Host: localhost:8080
 </tbody>
 </table>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 38. request-fields</caption>
+<caption class="title">Table 40. request-fields</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -3052,83 +3155,6 @@ Host: localhost:8080
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>content</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">수정된 댓글 내용</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code><strong>true</strong></code></p></td>
-</tr>
-</tbody>
-</table>
-<table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 39. request-headers</caption>
-<colgroup>
-<col style="width: 33.3333%;">
-<col style="width: 33.3333%;">
-<col style="width: 33.3334%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Name</th>
-<th class="tableblock halign-left valign-top">Description</th>
-<th class="tableblock halign-left valign-top">Required</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">JWT</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code><strong>true</strong></code></p></td>
-</tr>
-</tbody>
-</table>
-<div class="listingblock">
-<div class="title">http-response</div>
-<div class="content">
-<pre class="prettyprint highlight nowrap"><code data-lang="http">HTTP/1.1 200 OK
-Vary: Origin
-Vary: Access-Control-Request-Method
-Vary: Access-Control-Request-Headers
-X-Content-Type-Options: nosniff
-X-XSS-Protection: 1; mode=block
-Cache-Control: no-cache, no-store, max-age=0, must-revalidate
-Pragma: no-cache
-Expires: 0
-X-Frame-Options: DENY</code></pre>
-</div>
-</div>
-</div>
-<div class="sect2">
-<h3 id="_댓글_삭제">3.3. 댓글 삭제</h3>
-<div class="listingblock">
-<div class="title">curl-request</div>
-<div class="content">
-<pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/comments/35001' -i -X DELETE \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InVzZXJBQHRlc3QuY29tIiwic3ViIjoiMjAwMDEiLCJpYXQiOjE2NjkzNzM0MjQsImV4cCI6MTY2OTM3NzAyNH0.LwP17o2d0dk13pWqBDrsa6kkptMkrDT1L2yh7kjGA_E'</code></pre>
-</div>
-</div>
-<div class="listingblock">
-<div class="title">http-request</div>
-<div class="content">
-<pre class="prettyprint highlight nowrap"><code data-lang="http">DELETE /comments/35001 HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InVzZXJBQHRlc3QuY29tIiwic3ViIjoiMjAwMDEiLCJpYXQiOjE2NjkzNzM0MjQsImV4cCI6MTY2OTM3NzAyNH0.LwP17o2d0dk13pWqBDrsa6kkptMkrDT1L2yh7kjGA_E
-Host: localhost:8080</code></pre>
-</div>
-</div>
-<table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 40. /comments/{commentId}</caption>
-<colgroup>
-<col style="width: 33.3333%;">
-<col style="width: 33.3333%;">
-<col style="width: 33.3334%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Parameter</th>
-<th class="tableblock halign-left valign-top">Description</th>
-<th class="tableblock halign-left valign-top">Required</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>commentId</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">댓글 식별자</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code><strong>true</strong></code></p></td>
 </tr>
 </tbody>
@@ -3172,24 +3198,101 @@ X-Frame-Options: DENY</code></pre>
 </div>
 </div>
 <div class="sect2">
+<h3 id="_댓글_삭제">3.3. 댓글 삭제</h3>
+<div class="listingblock">
+<div class="title">curl-request</div>
+<div class="content">
+<pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/comments/35001' -i -X DELETE \
+    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InVzZXJBQHRlc3QuY29tIiwic3ViIjoiMjAwMDEiLCJpYXQiOjE2Njk1NDA5MDksImV4cCI6MTY2OTU0NDUwOX0.3UgQ_iKfpcSjfBdcKUcexubWg816arAfyvvyd0zj9lo'</code></pre>
+</div>
+</div>
+<div class="listingblock">
+<div class="title">http-request</div>
+<div class="content">
+<pre class="prettyprint highlight nowrap"><code data-lang="http">DELETE /comments/35001 HTTP/1.1
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InVzZXJBQHRlc3QuY29tIiwic3ViIjoiMjAwMDEiLCJpYXQiOjE2Njk1NDA5MDksImV4cCI6MTY2OTU0NDUwOX0.3UgQ_iKfpcSjfBdcKUcexubWg816arAfyvvyd0zj9lo
+Host: localhost:8080</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 42. /comments/{commentId}</caption>
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+<th class="tableblock halign-left valign-top">Required</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>commentId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">댓글 식별자</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code><strong>true</strong></code></p></td>
+</tr>
+</tbody>
+</table>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 43. request-headers</caption>
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Description</th>
+<th class="tableblock halign-left valign-top">Required</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">JWT</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code><strong>true</strong></code></p></td>
+</tr>
+</tbody>
+</table>
+<div class="listingblock">
+<div class="title">http-response</div>
+<div class="content">
+<pre class="prettyprint highlight nowrap"><code data-lang="http">HTTP/1.1 200 OK
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 1; mode=block
+Cache-Control: no-cache, no-store, max-age=0, must-revalidate
+Pragma: no-cache
+Expires: 0
+X-Frame-Options: DENY</code></pre>
+</div>
+</div>
+</div>
+<div class="sect2">
 <h3 id="_댓글_조회">3.4. 댓글 조회</h3>
 <div class="listingblock">
 <div class="title">curl-request</div>
 <div class="content">
-<pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/comments/board/21001?page=1&amp;size=5' -i -X GET \
+<pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/comments/board/21001?size=5' -i -X GET \
     -H 'Accept: application/json'</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">http-request</div>
 <div class="content">
-<pre class="prettyprint highlight nowrap"><code data-lang="http">GET /comments/board/21001?page=1&amp;size=5 HTTP/1.1
+<pre class="prettyprint highlight nowrap"><code data-lang="http">GET /comments/board/21001?size=5 HTTP/1.1
 Accept: application/json
 Host: localhost:8080</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 42. /comments/board/{boardId}</caption>
+<caption class="title">Table 44. /comments/board/{boardId}</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -3211,7 +3314,7 @@ Host: localhost:8080</code></pre>
 </tbody>
 </table>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 43. request-parameters</caption>
+<caption class="title">Table 45. request-parameters</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -3226,13 +3329,13 @@ Host: localhost:8080</code></pre>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>page</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">페이지</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>size</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">페이지 사이즈</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>false</code></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>size</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">페이지 사이즈</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>lastCommentId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">마지막 댓글 Id</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>false</code></p></td>
 </tr>
 </tbody>
@@ -3251,7 +3354,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 1606
+Content-Length: 1657
 
 {
   "content" : [ {
@@ -3264,15 +3367,6 @@ Content-Length: 1606
       "nickname" : "userA"
     }
   }, {
-    "commentId" : 25006,
-    "content" : "testComment",
-    "createdAt" : "2022-10-14T14:00:01",
-    "account" : {
-      "accountId" : 20003,
-      "profile" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
-      "nickname" : "userC"
-    }
-  }, {
     "commentId" : 25005,
     "content" : "testComment",
     "createdAt" : "2022-10-14T14:00:01",
@@ -3280,6 +3374,15 @@ Content-Length: 1606
       "accountId" : 20002,
       "profile" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
       "nickname" : "userB"
+    }
+  }, {
+    "commentId" : 25006,
+    "content" : "testComment",
+    "createdAt" : "2022-10-14T14:00:01",
+    "account" : {
+      "accountId" : 20003,
+      "profile" : "https://main-image-repo.s3.ap-northeast-2.amazonaws.com/39c10d6d-2765-479d-a45f-662e619fd006.jpeg",
+      "nickname" : "userC"
     }
   }, {
     "commentId" : 25001,
@@ -3308,7 +3411,7 @@ Content-Length: 1606
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 44. response-fields</caption>
+<caption class="title">Table 46. response-fields</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -3397,19 +3500,19 @@ Content-Length: 1606
 <div class="title">curl-request</div>
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/follows/10002' -i -X POST \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjkzNzM0MjQsImV4cCI6MTY2OTM3NzAyNH0.t4KBF1teJ6nRe-SiZoiv2dGGkrh2f1xKtiCi_au9e-4'</code></pre>
+    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njk1NDA5MTAsImV4cCI6MTY2OTU0NDUxMH0.9bduoiFRBNQM0OquCW9YUJksghTNLq8v-nbd3YTuHBk'</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">http-request</div>
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">POST /follows/10002 HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjkzNzM0MjQsImV4cCI6MTY2OTM3NzAyNH0.t4KBF1teJ6nRe-SiZoiv2dGGkrh2f1xKtiCi_au9e-4
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njk1NDA5MTAsImV4cCI6MTY2OTU0NDUxMH0.9bduoiFRBNQM0OquCW9YUJksghTNLq8v-nbd3YTuHBk
 Host: localhost:8080</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 45. request-headers</caption>
+<caption class="title">Table 47. request-headers</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -3431,7 +3534,7 @@ Host: localhost:8080</code></pre>
 </tbody>
 </table>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 46. /follows/{accountId}</caption>
+<caption class="title">Table 48. /follows/{accountId}</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -3466,7 +3569,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 26
+Content-Length: 28
 
 {
   "status" : "SUCCESS"
@@ -3474,7 +3577,7 @@ Content-Length: 26
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 47. response-fields</caption>
+<caption class="title">Table 49. response-fields</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -3502,19 +3605,19 @@ Content-Length: 26
 <div class="title">curl-request</div>
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/follows/10002' -i -X GET \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjkzNzM0MjQsImV4cCI6MTY2OTM3NzAyNH0.t4KBF1teJ6nRe-SiZoiv2dGGkrh2f1xKtiCi_au9e-4'</code></pre>
+    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njk1NDA5MTAsImV4cCI6MTY2OTU0NDUxMH0.9bduoiFRBNQM0OquCW9YUJksghTNLq8v-nbd3YTuHBk'</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">http-request</div>
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">GET /follows/10002 HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjkzNzM0MjQsImV4cCI6MTY2OTM3NzAyNH0.t4KBF1teJ6nRe-SiZoiv2dGGkrh2f1xKtiCi_au9e-4
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njk1NDA5MTAsImV4cCI6MTY2OTU0NDUxMH0.9bduoiFRBNQM0OquCW9YUJksghTNLq8v-nbd3YTuHBk
 Host: localhost:8080</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 48. request-headers</caption>
+<caption class="title">Table 50. request-headers</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -3536,7 +3639,7 @@ Host: localhost:8080</code></pre>
 </tbody>
 </table>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 49. /follows/{accountId}</caption>
+<caption class="title">Table 51. /follows/{accountId}</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -3571,7 +3674,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 21
+Content-Length: 23
 
 {
   "follow" : true
@@ -3579,7 +3682,7 @@ Content-Length: 21
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 50. response-fields</caption>
+<caption class="title">Table 52. response-fields</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -3613,19 +3716,19 @@ Content-Length: 21
 <div class="title">curl-request</div>
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/likes/12002' -i -X POST \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjkzNzM0MjUsImV4cCI6MTY2OTM3NzAyNX0.rVG_rGpmqyX0WDbS1UNcD6SKb6gpPfyYfatOGv9GisA'</code></pre>
+    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njk1NDA5MTAsImV4cCI6MTY2OTU0NDUxMH0.9bduoiFRBNQM0OquCW9YUJksghTNLq8v-nbd3YTuHBk'</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">http-request</div>
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">POST /likes/12002 HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjkzNzM0MjUsImV4cCI6MTY2OTM3NzAyNX0.rVG_rGpmqyX0WDbS1UNcD6SKb6gpPfyYfatOGv9GisA
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njk1NDA5MTAsImV4cCI6MTY2OTU0NDUxMH0.9bduoiFRBNQM0OquCW9YUJksghTNLq8v-nbd3YTuHBk
 Host: localhost:8080</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 51. request-headers</caption>
+<caption class="title">Table 53. request-headers</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -3647,7 +3750,7 @@ Host: localhost:8080</code></pre>
 </tbody>
 </table>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 52. /likes/{boardId}</caption>
+<caption class="title">Table 54. /likes/{boardId}</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -3682,7 +3785,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 26
+Content-Length: 28
 
 {
   "status" : "SUCCESS"
@@ -3690,7 +3793,7 @@ Content-Length: 26
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 53. response-fields</caption>
+<caption class="title">Table 55. response-fields</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -3718,19 +3821,19 @@ Content-Length: 26
 <div class="title">curl-request</div>
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/likes/12002' -i -X GET \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjkzNzM0MjUsImV4cCI6MTY2OTM3NzAyNX0.rVG_rGpmqyX0WDbS1UNcD6SKb6gpPfyYfatOGv9GisA'</code></pre>
+    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njk1NDA5MTAsImV4cCI6MTY2OTU0NDUxMH0.9bduoiFRBNQM0OquCW9YUJksghTNLq8v-nbd3YTuHBk'</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">http-request</div>
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">GET /likes/12002 HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjkzNzM0MjUsImV4cCI6MTY2OTM3NzAyNX0.rVG_rGpmqyX0WDbS1UNcD6SKb6gpPfyYfatOGv9GisA
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njk1NDA5MTAsImV4cCI6MTY2OTU0NDUxMH0.9bduoiFRBNQM0OquCW9YUJksghTNLq8v-nbd3YTuHBk
 Host: localhost:8080</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 54. request-headers</caption>
+<caption class="title">Table 56. request-headers</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -3752,7 +3855,7 @@ Host: localhost:8080</code></pre>
 </tbody>
 </table>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 55. /likes/{boardId}</caption>
+<caption class="title">Table 57. /likes/{boardId}</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -3787,7 +3890,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 20
+Content-Length: 22
 
 {
   "likes" : true
@@ -3795,7 +3898,7 @@ Content-Length: 20
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 56. response-fields</caption>
+<caption class="title">Table 58. response-fields</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -3830,7 +3933,7 @@ Content-Length: 20
 <div class="content">
 <pre class="prettyprint highlight"><code data-lang="bash">$ curl 'http://localhost:8080/image-files' -i -X POST \
     -H 'Content-Type: multipart/form-data;charset=UTF-8' \
-    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjkzNzM0MjUsImV4cCI6MTY2OTM3NzAyNX0.rVG_rGpmqyX0WDbS1UNcD6SKb6gpPfyYfatOGv9GisA' \
+    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njk1NDA5MTAsImV4cCI6MTY2OTU0NDUxMH0.9bduoiFRBNQM0OquCW9YUJksghTNLq8v-nbd3YTuHBk' \
     -F 'images=@image1.jpeg;type=image/jpeg' \
     -F 'images=@image2.jpeg;type=image/jpeg' \
     -F 'images=@image3.jpeg;type=image/jpeg'</code></pre>
@@ -3841,7 +3944,7 @@ Content-Length: 20
 <div class="content">
 <pre class="prettyprint highlight nowrap"><code data-lang="http">POST /image-files HTTP/1.1
 Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2NjkzNzM0MjUsImV4cCI6MTY2OTM3NzAyNX0.rVG_rGpmqyX0WDbS1UNcD6SKb6gpPfyYfatOGv9GisA
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJyb2xlIjpbIlJPTEVfVVNFUiJdLCJlbWFpbCI6InRlc3QxQHRlc3QuY29tIiwic3ViIjoiMTAwMDEiLCJpYXQiOjE2Njk1NDA5MTAsImV4cCI6MTY2OTU0NDUxMH0.9bduoiFRBNQM0OquCW9YUJksghTNLq8v-nbd3YTuHBk
 Host: localhost:8080
 
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
@@ -3863,7 +3966,7 @@ Content-Type: image/jpeg
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 57. request-headers</caption>
+<caption class="title">Table 59. request-headers</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -3885,7 +3988,7 @@ Content-Type: image/jpeg
 </tbody>
 </table>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 58. request-parts</caption>
+<caption class="title">Table 60. request-parts</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -3920,15 +4023,15 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 260
+Content-Length: 262
 
 {
-  "imagePaths" : [ "http://localhost:8080/image-files/1d486074-ad59-4ba5-8ffc-b728c76ba9c5.jpeg", "http://localhost:8080/image-files/3c0bc7ef-ba27-4eec-8a1f-10f0cfbfddab.jpeg", "http://localhost:8080/image-files/705ce8ad-3b35-4cda-b833-1cc78cd73778.jpeg" ]
+  "imagePaths" : [ "http://localhost:8080/image-files/38c26929-0deb-4aed-8ec9-2dec501ea835.jpeg", "http://localhost:8080/image-files/2709a991-3712-4dbf-90ba-4885f11d1683.jpeg", "http://localhost:8080/image-files/6b487f8d-e509-402a-a3b0-1aaefb86df47.jpeg" ]
 }</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 59. response-fields</caption>
+<caption class="title">Table 61. response-fields</caption>
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -3956,7 +4059,7 @@ Content-Length: 260
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2022-11-25 19:48:27 +0900
+Last updated 2022-11-27 18:18:04 +0900
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prettify/r298/prettify.min.css">

--- a/back/src/test/java/travelRepo/domain/board/controller/BoardControllerTest.java
+++ b/back/src/test/java/travelRepo/domain/board/controller/BoardControllerTest.java
@@ -463,20 +463,10 @@ class BoardControllerTest extends After {
     public void boardList_Success() throws Exception {
 
         //given
-//        String query = null;
-        String category = null;
-        int page = 1;
-        int size = 20;
-        String sort = "createdAt,DESC";
 
         //when
         ResultActions actions = mockMvc.perform(
                 get("/boards")
-//                        .param("query", query)
-                        .param("category", category)
-                        .param("page", String.valueOf(page))
-                        .param("size", String.valueOf(size))
-                        .param("sort", sort)
                         .accept(MediaType.APPLICATION_JSON)
         );
 
@@ -493,11 +483,13 @@ class BoardControllerTest extends After {
                         getResponsePreProcessor(),
                         requestParameters(
                                 List.of(
-//                                        parameterWithName("query").description("검색어").optional(),
+                                        parameterWithName("query").description("검색어").optional(),
                                         parameterWithName("category").description("게시글 분류").optional(),
-                                        parameterWithName("page").description("페이지").optional(),
                                         parameterWithName("size").description("페이지 사이즈").optional(),
-                                        parameterWithName("sort").description("정렬 기준").optional()
+                                        parameterWithName("sort").description("정렬 기준").optional(),
+                                        parameterWithName("lastBoardId").description("마지막 게시글 Id").optional(),
+                                        parameterWithName("lastBoardViews").description("마지막 게시글 조회수").optional(),
+                                        parameterWithName("lastBoardLikeCount").description("마지막 게시글 추천수").optional()
                                 )
                         ),
                         responseFields(
@@ -507,6 +499,7 @@ class BoardControllerTest extends After {
                                         fieldWithPath("content[].thumbnail").type(JsonFieldType.STRING).description("게시글 썸네일"),
                                         fieldWithPath("content[].title").type(JsonFieldType.STRING).description("게시글 제목"),
                                         fieldWithPath("content[].likeCount").type(JsonFieldType.NUMBER).description("게시글 좋아요 수"),
+                                        fieldWithPath("content[].views").type(JsonFieldType.NUMBER).description("게시글 조휘수"),
                                         fieldWithPath("content[].tags").type(JsonFieldType.ARRAY).description("게시글 태그"),
                                         fieldWithPath("content[].account").type(JsonFieldType.OBJECT).description("글쓴이"),
                                         fieldWithPath("content[].account.accountId").type(JsonFieldType.NUMBER).description("계정 식별자"),
@@ -593,6 +586,11 @@ class BoardControllerTest extends After {
                         pathParameters(
                                 parameterWithName("accountId").description("계정 식별자")
                         ),
+                        requestParameters(
+                                List.of(
+                                        parameterWithName("lastBoardId").description("마지막 게시글 Id").optional()
+                                )
+                        ),
                         responseFields(
                                 List.of(
                                         fieldWithPath("content[]").type(JsonFieldType.ARRAY).description("게시물 목록"),
@@ -600,6 +598,7 @@ class BoardControllerTest extends After {
                                         fieldWithPath("content[].thumbnail").type(JsonFieldType.STRING).description("게시글 썸네일"),
                                         fieldWithPath("content[].title").type(JsonFieldType.STRING).description("게시글 제목"),
                                         fieldWithPath("content[].likeCount").type(JsonFieldType.NUMBER).description("게시글 좋아요 수"),
+                                        fieldWithPath("content[].views").type(JsonFieldType.NUMBER).description("게시글 조회수/실제와 차이 있음"),
                                         fieldWithPath("content[].tags").type(JsonFieldType.ARRAY).description("게시글 태그"),
                                         fieldWithPath("content[].account").type(JsonFieldType.OBJECT).description("글쓴이"),
                                         fieldWithPath("content[].account.accountId").type(JsonFieldType.NUMBER).description("계정 식별자"),
@@ -645,6 +644,7 @@ class BoardControllerTest extends After {
                                 List.of(
                                         fieldWithPath("content[]").type(JsonFieldType.ARRAY).description("게시물 목록"),
                                         fieldWithPath("content[].boardId").type(JsonFieldType.NUMBER).description("게시글 식별자"),
+                                        fieldWithPath("content[].likeId").type(JsonFieldType.NUMBER).description("게시글 식별자"),
                                         fieldWithPath("content[].thumbnail").type(JsonFieldType.STRING).description("게시글 썸네일"),
                                         fieldWithPath("content[].title").type(JsonFieldType.STRING).description("게시글 제목"),
                                         fieldWithPath("content[].likeCount").type(JsonFieldType.NUMBER).description("게시글 좋아요 수"),

--- a/back/src/test/java/travelRepo/domain/board/controller/BoardControllerTest.java
+++ b/back/src/test/java/travelRepo/domain/board/controller/BoardControllerTest.java
@@ -428,7 +428,7 @@ class BoardControllerTest extends After {
                                         fieldWithPath("views").type(JsonFieldType.NUMBER).description("조회수"),
                                         fieldWithPath("tags").type(JsonFieldType.ARRAY).description("게시글 태그"),
                                         fieldWithPath("photos").type(JsonFieldType.ARRAY).description("사진 주소"),
-                                        fieldWithPath("createdAt").type(JsonFieldType.STRING).description("게시글 생성 날짜"),
+                                        fieldWithPath("createdAt").type(JsonFieldType.STRING).description("게시글 생성 시각"),
                                         fieldWithPath("account").type(JsonFieldType.OBJECT).description("글쓴이"),
                                         fieldWithPath("account.accountId").type(JsonFieldType.NUMBER).description("계정 식별자"),
                                         fieldWithPath("account.profile").type(JsonFieldType.STRING).description("프로필 사진"),
@@ -488,6 +488,7 @@ class BoardControllerTest extends After {
                                         parameterWithName("size").description("페이지 사이즈").optional(),
                                         parameterWithName("sort").description("정렬 기준").optional(),
                                         parameterWithName("lastBoardId").description("마지막 게시글 Id").optional(),
+                                        parameterWithName("lastBoardCreatedAt").description("마지막 게시글 생성 시각").optional(),
                                         parameterWithName("lastBoardViews").description("마지막 게시글 조회수").optional(),
                                         parameterWithName("lastBoardLikeCount").description("마지막 게시글 추천수").optional()
                                 )
@@ -500,6 +501,7 @@ class BoardControllerTest extends After {
                                         fieldWithPath("content[].title").type(JsonFieldType.STRING).description("게시글 제목"),
                                         fieldWithPath("content[].likeCount").type(JsonFieldType.NUMBER).description("게시글 좋아요 수"),
                                         fieldWithPath("content[].views").type(JsonFieldType.NUMBER).description("게시글 조휘수"),
+                                        fieldWithPath("content[].createdAt").type(JsonFieldType.STRING).description("게시글 생성 시각"),
                                         fieldWithPath("content[].tags").type(JsonFieldType.ARRAY).description("게시글 태그"),
                                         fieldWithPath("content[].account").type(JsonFieldType.OBJECT).description("글쓴이"),
                                         fieldWithPath("content[].account.accountId").type(JsonFieldType.NUMBER).description("계정 식별자"),
@@ -588,7 +590,8 @@ class BoardControllerTest extends After {
                         ),
                         requestParameters(
                                 List.of(
-                                        parameterWithName("lastBoardId").description("마지막 게시글 Id").optional()
+                                        parameterWithName("lastBoardId").description("마지막 게시글 Id").optional(),
+                                        parameterWithName("lastBoardCreatedAt").description("마지막 게시글 생성 시각").optional()
                                 )
                         ),
                         responseFields(
@@ -599,6 +602,7 @@ class BoardControllerTest extends After {
                                         fieldWithPath("content[].title").type(JsonFieldType.STRING).description("게시글 제목"),
                                         fieldWithPath("content[].likeCount").type(JsonFieldType.NUMBER).description("게시글 좋아요 수"),
                                         fieldWithPath("content[].views").type(JsonFieldType.NUMBER).description("게시글 조회수/실제와 차이 있음"),
+                                        fieldWithPath("content[].createdAt").type(JsonFieldType.STRING).description("게시글 생성 시각"),
                                         fieldWithPath("content[].tags").type(JsonFieldType.ARRAY).description("게시글 태그"),
                                         fieldWithPath("content[].account").type(JsonFieldType.OBJECT).description("글쓴이"),
                                         fieldWithPath("content[].account.accountId").type(JsonFieldType.NUMBER).description("계정 식별자"),
@@ -642,18 +646,20 @@ class BoardControllerTest extends After {
                         ),
                         requestParameters(
                                 List.of(
-                                        parameterWithName("lastLikeId").description("마지막 게시글의 likeId").optional()
+                                        parameterWithName("lastLikeId").description("마지막 게시글의 likeId").optional(),
+                                        parameterWithName("lastLikeId").description("마지막 게시글의 like 시각").optional()
                                 )
                         ),
                         responseFields(
                                 List.of(
                                         fieldWithPath("content[]").type(JsonFieldType.ARRAY).description("게시물 목록"),
                                         fieldWithPath("content[].boardId").type(JsonFieldType.NUMBER).description("게시글 식별자"),
-                                        fieldWithPath("content[].likeId").type(JsonFieldType.NUMBER).description("게시글 식별자"),
                                         fieldWithPath("content[].thumbnail").type(JsonFieldType.STRING).description("게시글 썸네일"),
                                         fieldWithPath("content[].title").type(JsonFieldType.STRING).description("게시글 제목"),
                                         fieldWithPath("content[].likeCount").type(JsonFieldType.NUMBER).description("게시글 좋아요 수"),
                                         fieldWithPath("content[].tags").type(JsonFieldType.ARRAY).description("게시글 태그"),
+                                        fieldWithPath("content[].likeId").type(JsonFieldType.NUMBER).description("좋아요 Id"),
+                                        fieldWithPath("content[].likeCreatedAt").type(JsonFieldType.STRING).description("좋아요 시각"),
                                         fieldWithPath("content[].account").type(JsonFieldType.OBJECT).description("글쓴이"),
                                         fieldWithPath("content[].account.accountId").type(JsonFieldType.NUMBER).description("계정 식별자"),
                                         fieldWithPath("content[].account.profile").type(JsonFieldType.STRING).description("프로필 사진"),

--- a/back/src/test/java/travelRepo/domain/board/controller/BoardControllerTest.java
+++ b/back/src/test/java/travelRepo/domain/board/controller/BoardControllerTest.java
@@ -640,6 +640,11 @@ class BoardControllerTest extends After {
                         pathParameters(
                                 parameterWithName("accountId").description("계정 식별자")
                         ),
+                        requestParameters(
+                                List.of(
+                                        parameterWithName("lastLikeId").description("마지막 게시글의 likeId").optional()
+                                )
+                        ),
                         responseFields(
                                 List.of(
                                         fieldWithPath("content[]").type(JsonFieldType.ARRAY).description("게시물 목록"),

--- a/back/src/test/java/travelRepo/domain/board/controller/BoardControllerTest.java
+++ b/back/src/test/java/travelRepo/domain/board/controller/BoardControllerTest.java
@@ -463,7 +463,7 @@ class BoardControllerTest extends After {
     public void boardList_Success() throws Exception {
 
         //given
-        String query = null;
+//        String query = null;
         String category = null;
         int page = 1;
         int size = 20;
@@ -472,7 +472,7 @@ class BoardControllerTest extends After {
         //when
         ResultActions actions = mockMvc.perform(
                 get("/boards")
-                        .param("query", query)
+//                        .param("query", query)
                         .param("category", category)
                         .param("page", String.valueOf(page))
                         .param("size", String.valueOf(size))
@@ -493,7 +493,7 @@ class BoardControllerTest extends After {
                         getResponsePreProcessor(),
                         requestParameters(
                                 List.of(
-                                        parameterWithName("query").description("검색어").optional(),
+//                                        parameterWithName("query").description("검색어").optional(),
                                         parameterWithName("category").description("게시글 분류").optional(),
                                         parameterWithName("page").description("페이지").optional(),
                                         parameterWithName("size").description("페이지 사이즈").optional(),

--- a/back/src/test/java/travelRepo/domain/comment/controller/CommentControllerTest.java
+++ b/back/src/test/java/travelRepo/domain/comment/controller/CommentControllerTest.java
@@ -376,7 +376,8 @@ class CommentControllerTest {
                         requestParameters(
                                 List.of(
                                         parameterWithName("size").description("페이지 사이즈").optional(),
-                                        parameterWithName("lastCommentId").description("마지막 댓글 Id").optional()
+                                        parameterWithName("lastCommentId").description("마지막 댓글 Id").optional(),
+                                        parameterWithName("lastCommentCreatedAt").description("마지막 댓글 생성 시각").optional()
                                 )
                         ),
                         responseFields(

--- a/back/src/test/java/travelRepo/domain/comment/controller/CommentControllerTest.java
+++ b/back/src/test/java/travelRepo/domain/comment/controller/CommentControllerTest.java
@@ -349,13 +349,11 @@ class CommentControllerTest {
 
         //given
         Long boardId = 21001L;
-        int page = 1;
         int size = 5;
 
         //when
         ResultActions actions = mockMvc.perform(
                 get("/comments/board/{boardId}", boardId)
-                        .param("page", String.valueOf(page))
                         .param("size", String.valueOf(size))
                         .accept(MediaType.APPLICATION_JSON)
         );
@@ -377,8 +375,8 @@ class CommentControllerTest {
                         ),
                         requestParameters(
                                 List.of(
-                                        parameterWithName("page").description("페이지").optional(),
-                                        parameterWithName("size").description("페이지 사이즈").optional()
+                                        parameterWithName("size").description("페이지 사이즈").optional(),
+                                        parameterWithName("lastCommentId").description("마지막 댓글 Id").optional()
                                 )
                         ),
                         responseFields(


### PR DESCRIPTION
무한스크롤이 적용되는 API의 페이지네이션을 offset 방식에서 cursor 방식으로 변경했습니다. 현재는 이전 방식과 바뀐 방식 모두 지원하도록 했고, 프론트 분들께서 요청 데이터를 변경하면 기존 방식은 삭제할 예정입니다.

cursor 방식의 페이지네이션을 적용하기 위해 응답 데이터를 추가했습니다.
  - 게시글 조회/검색 응답 데이터에 조회수를 추가했습니다.
  - 좋아요한 게시글 응답 데이터를 분리하고 likdId를 추가했습니다.

변경된 API에 맞춰 테스트와 명세서를 수정했습니다.