### PR TITLE
[Feat] 내정보-팔로워, 팔로잉 탭 반응형, 데이터 연결 및 팔로우 팔로잉 버튼 연결

### DIFF
--- a/front/src/component/common/header/HeaderDropDownItem.jsx
+++ b/front/src/component/common/header/HeaderDropDownItem.jsx
@@ -24,7 +24,7 @@ const ItemWrapper = styled.li`
   }
 `;
 
-function HedaerDropDownItem({ linkText, link, activeHandler }) {
+function HeaderDropDownItem({ linkText, link, activeHandler }) {
   // 로그아웃 핸들러
   const logoutHandler = () => {
     console.log('로그아웃 핸들러 앞');
@@ -58,4 +58,4 @@ function HedaerDropDownItem({ linkText, link, activeHandler }) {
   );
 }
 
-export default HedaerDropDownItem;
+export default HeaderDropDownItem;

--- a/front/src/component/follow/FollowList.jsx
+++ b/front/src/component/follow/FollowList.jsx
@@ -64,16 +64,16 @@ const FollowListContainer = styled.div`
   }
 `;
 
-function FollowList() {
+function FollowList({ myFollowing }) {
   return (
     <FollowListContainer>
       <div className="followList__leftside">
         <ul className="followList__userinfo">
           <li className="followList__avatar">
-            <img src="https://source.unsplash.com/random" alt="아바타" />
+            <img src={myFollowing.profile} alt="아바타" />
           </li>
           <li className="followList__username">
-            <p>남극에서온펭귄</p>
+            <p>{myFollowing.nickname}</p>
           </li>
           <li className="followList__button">
             <DefaultButton width="9rem" height="3rem">
@@ -84,11 +84,10 @@ function FollowList() {
       </div>
       <div className="followList__rightside">
         <ul className="followList__posts">
-          <FollowPost />
-          <FollowPost />
-          <FollowPost />
-          <FollowPost />
-          <FollowPost />
+          {myFollowing &&
+            myFollowing.boards.map(board => (
+              <FollowPost key={board.id} boards={board} />
+            ))}
         </ul>
       </div>
     </FollowListContainer>

--- a/front/src/component/follow/FollowList.jsx
+++ b/front/src/component/follow/FollowList.jsx
@@ -23,6 +23,10 @@ const FollowListContainer = styled.div`
 
   .followList__leftside {
     padding: 0 5rem 0 1.2rem;
+
+    @media screen and (max-width: 549px) {
+      padding-right: 1.2rem;
+    }
     .followList__userinfo {
       display: flex;
       flex-direction: column;
@@ -65,6 +69,7 @@ const FollowListContainer = styled.div`
 `;
 
 function FollowList({ myFollowing }) {
+  console.log(myFollowing);
   return (
     <FollowListContainer>
       <div className="followList__leftside">

--- a/front/src/component/follow/FollowList.jsx
+++ b/front/src/component/follow/FollowList.jsx
@@ -1,5 +1,4 @@
 import styled from 'styled-components';
-
 import FollowPost from './FollowPost';
 import FollowUserCard from './FollowUserCard';
 
@@ -20,45 +19,6 @@ const FollowListContainer = styled.div`
   }
   &:last-child::after {
     display: none;
-  }
-
-  .followList__leftside {
-    padding: 0 5rem 0 1.2rem;
-
-    @media screen and (max-width: 549px) {
-      padding-right: 1.2rem;
-    }
-    .followList__userinfo {
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      padding: 5rem 0;
-
-      .followList__avatar {
-        width: 12rem;
-        height: 12rem;
-        border-radius: 50%;
-        background: #eee;
-        overflow: hidden;
-        > img {
-          width: 100%;
-          height: 100%;
-        }
-      }
-
-      .followList__username {
-        margin: 1rem 0 2rem;
-        > p {
-          font-size: 1.4rem;
-          overflow: hidden;
-          text-overflow: ellipsis;
-          display: -webkit-box;
-          -webkit-line-clamp: 1;
-          -webkit-box-orient: vertical;
-          word-break: break-all;
-        }
-      }
-    }
   }
 
   .followList__rightside {

--- a/front/src/component/follow/FollowList.jsx
+++ b/front/src/component/follow/FollowList.jsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
-import { DefaultButton } from '../common/button/ButtonStyle';
+
 import FollowPost from './FollowPost';
+import FollowUserCard from './FollowUserCard';
 
 const FollowListContainer = styled.div`
   display: flex;
@@ -69,24 +70,9 @@ const FollowListContainer = styled.div`
 `;
 
 function FollowList({ myFollowing }) {
-  console.log(myFollowing);
   return (
     <FollowListContainer>
-      <div className="followList__leftside">
-        <ul className="followList__userinfo">
-          <li className="followList__avatar">
-            <img src={myFollowing.profile} alt="아바타" />
-          </li>
-          <li className="followList__username">
-            <p>{myFollowing.nickname}</p>
-          </li>
-          <li className="followList__button">
-            <DefaultButton width="9rem" height="3rem">
-              팔로우
-            </DefaultButton>
-          </li>
-        </ul>
-      </div>
+      <FollowUserCard myFollowing={myFollowing} />
       <div className="followList__rightside">
         <ul className="followList__posts">
           {myFollowing &&

--- a/front/src/component/follow/FollowPost.jsx
+++ b/front/src/component/follow/FollowPost.jsx
@@ -43,18 +43,16 @@ const FollowThumb = styled.li`
   }
 `;
 
-function FollowPost() {
+function FollowPost({ boards }) {
+  console.log(boards);
   return (
     <FollowThumb>
       <div className="FollowThumb__container">
         <div className="followThumb__img">
-          <img
-            src="https://source.unsplash.com/random"
-            alt="팔로우썸네일이미지"
-          />
+          <img src={boards.thumbnail} alt="팔로우썸네일이미지" />
         </div>
         <div className="followThumb__title">
-          <p>남극참치맛있어요</p>
+          <p>{boards.title}</p>
         </div>
       </div>
     </FollowThumb>

--- a/front/src/component/follow/FollowPost.jsx
+++ b/front/src/component/follow/FollowPost.jsx
@@ -4,6 +4,35 @@ const FollowThumb = styled.li`
   flex-basis: 20%;
   padding: 0 1.2rem;
 
+  @media screen and (max-width: 1440px) {
+    flex-basis: 25%;
+    &:nth-child(5) {
+      display: none;
+    }
+  }
+
+  @media screen and (max-width: 1024px) {
+    flex-basis: 33.3%;
+    &:nth-child(4) {
+      display: none;
+    }
+  }
+
+  @media screen and (max-width: 768px) {
+    flex-basis: 50%;
+    &:nth-child(3) {
+      display: none;
+    }
+  }
+
+  @media screen and (max-width: 549px) {
+    margin: 0 1rem;
+    flex-basis: 100%;
+    &:nth-child(2) {
+      display: none;
+    }
+  }
+
   .FollowThumb__container {
     display: flex;
     flex-direction: column;
@@ -44,7 +73,6 @@ const FollowThumb = styled.li`
 `;
 
 function FollowPost({ boards }) {
-  console.log(boards);
   return (
     <FollowThumb>
       <div className="FollowThumb__container">

--- a/front/src/component/follow/FollowUserCard.jsx
+++ b/front/src/component/follow/FollowUserCard.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { DefaultButton, NegativeButton } from '../common/button/ButtonStyle';
+
+function FollowUserCard({ myFollowing }) {
+  return (
+    <div className="followList__leftside">
+      <ul className="followList__userinfo">
+        <li className="followList__avatar">
+          <img src={myFollowing.profile} alt="아바타" />
+        </li>
+        <li className="followList__username">
+          <p>{myFollowing.nickname}</p>
+        </li>
+        <li className="followList__button">
+          {!myFollowing.follow ? (
+            <DefaultButton width="9rem" height="3rem">
+              팔로우
+            </DefaultButton>
+          ) : (
+            <NegativeButton width="9rem" height="3rem">
+              언팔로우
+            </NegativeButton>
+          )}
+        </li>
+      </ul>
+    </div>
+  );
+}
+
+export default FollowUserCard;

--- a/front/src/component/follow/FollowUserCard.jsx
+++ b/front/src/component/follow/FollowUserCard.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { DefaultButton, NegativeButton } from '../common/button/ButtonStyle';
+import { postDetailFollowApi } from '../../api/postDetailApi';
 
 const FollowListLeftSide = styled.div`
   padding: 0 5rem 0 1.2rem;
@@ -42,6 +43,13 @@ const FollowListLeftSide = styled.div`
 `;
 
 function FollowUserCard({ myFollowing }) {
+  console.log(myFollowing);
+
+  const followHandler = () => {
+    postDetailFollowApi(myFollowing.id);
+    window.location.reload();
+  };
+
   return (
     <FollowListLeftSide>
       <ul className="followList__userinfo">
@@ -53,11 +61,11 @@ function FollowUserCard({ myFollowing }) {
         </li>
         <li className="followList__button">
           {!myFollowing.follow ? (
-            <DefaultButton width="9rem" height="3rem">
+            <DefaultButton width="9rem" height="3rem" onClick={followHandler}>
               팔로우
             </DefaultButton>
           ) : (
-            <NegativeButton width="9rem" height="3rem">
+            <NegativeButton width="9rem" height="3rem" onClick={followHandler}>
               언팔로우
             </NegativeButton>
           )}

--- a/front/src/component/follow/FollowUserCard.jsx
+++ b/front/src/component/follow/FollowUserCard.jsx
@@ -1,9 +1,49 @@
 import React from 'react';
+import styled from 'styled-components';
 import { DefaultButton, NegativeButton } from '../common/button/ButtonStyle';
+
+const FollowListLeftSide = styled.div`
+  padding: 0 5rem 0 1.2rem;
+
+  @media screen and (max-width: 549px) {
+    padding-right: 1.2rem;
+  }
+  .followList__userinfo {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 5rem 0;
+
+    .followList__avatar {
+      width: 12rem;
+      height: 12rem;
+      border-radius: 50%;
+      background: #eee;
+      overflow: hidden;
+      > img {
+        width: 100%;
+        height: 100%;
+      }
+    }
+
+    .followList__username {
+      margin: 1rem 0 2rem;
+      > p {
+        font-size: 1.4rem;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        display: -webkit-box;
+        -webkit-line-clamp: 1;
+        -webkit-box-orient: vertical;
+        word-break: break-all;
+      }
+    }
+  }
+`;
 
 function FollowUserCard({ myFollowing }) {
   return (
-    <div className="followList__leftside">
+    <FollowListLeftSide>
       <ul className="followList__userinfo">
         <li className="followList__avatar">
           <img src={myFollowing.profile} alt="아바타" />
@@ -23,7 +63,7 @@ function FollowUserCard({ myFollowing }) {
           )}
         </li>
       </ul>
-    </div>
+    </FollowListLeftSide>
   );
 }
 

--- a/front/src/pages/myPages/MyFollower.jsx
+++ b/front/src/pages/myPages/MyFollower.jsx
@@ -7,6 +7,8 @@ const MyPageMain = styled.main`
   padding-top: 20rem;
   max-width: 172rem;
   margin: 0 3rem;
+  width: 90%;
+
   @media screen and (max-width: 549px) {
     padding-top: 15rem;
     margin: 0 1rem;

--- a/front/src/pages/myPages/MyFollower.jsx
+++ b/front/src/pages/myPages/MyFollower.jsx
@@ -4,7 +4,7 @@ import FollowList from '../../component/follow/FollowList';
 import followDataApi from '../../api/followDataApi';
 
 const MyPageMain = styled.main`
-  padding-top: 20rem;
+  padding-top: 22rem;
   max-width: 172rem;
   margin: 0 3rem;
   width: 90%;

--- a/front/src/pages/myPages/MyFollower.jsx
+++ b/front/src/pages/myPages/MyFollower.jsx
@@ -1,34 +1,32 @@
-import React, { useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import FollowList from '../../component/follow/FollowList';
 import followDataApi from '../../api/followDataApi';
 
 const MyPageMain = styled.main`
-  width: 100%;
-  display: flex;
-  justify-content: center;
   padding-top: 20rem;
-
-  .follower__container {
-    width: 100%;
-    max-width: 172rem;
-    margin: 5rem 3rem 0;
+  max-width: 172rem;
+  margin: 0 3rem;
+  @media screen and (max-width: 549px) {
+    padding-top: 15rem;
+    margin: 0 1rem;
   }
 `;
 
 function MyFollower() {
+  const [myFollowing, setMyFollowing] = useState([]);
   useEffect(() => {
     followDataApi(1, 'follower')
-      .then(res => console.log(res))
+      .then(res => {
+        return setMyFollowing(res.data.content);
+      })
       .catch(err => console.log(err));
   }, []);
   return (
     <MyPageMain>
-      <section className="follower__container">
-        <FollowList />
-        <FollowList />
-        <FollowList />
-      </section>
+      {myFollowing.map(following => (
+        <FollowList key={following.id} myFollowing={following} />
+      ))}
     </MyPageMain>
   );
 }

--- a/front/src/pages/myPages/MyFollowing.jsx
+++ b/front/src/pages/myPages/MyFollowing.jsx
@@ -7,6 +7,8 @@ const MyPageMain = styled.main`
   padding-top: 20rem;
   max-width: 172rem;
   margin: 0 3rem;
+  width: 90%;
+
   @media screen and (max-width: 549px) {
     padding-top: 15rem;
     margin: 0 1rem;

--- a/front/src/pages/myPages/MyFollowing.jsx
+++ b/front/src/pages/myPages/MyFollowing.jsx
@@ -1,6 +1,7 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import followDataApi from '../../api/followDataApi';
+import FollowList from '../../component/follow/FollowList';
 
 const MyPageMain = styled.main`
   padding-top: 23rem;
@@ -9,12 +10,21 @@ const MyPageMain = styled.main`
 `;
 
 function MyFollowing() {
+  const [myFollowing, setMyFollowing] = useState([]);
   useEffect(() => {
     followDataApi(1, 'following')
-      .then(res => console.log(res))
+      .then(res => {
+        return setMyFollowing(res.data.content);
+      })
       .catch(err => console.log(err));
   }, []);
-  return <MyPageMain>MyFollowing</MyPageMain>;
+  return (
+    <MyPageMain>
+      {myFollowing.map(following => (
+        <FollowList key={following.id} myFollowing={following} />
+      ))}
+    </MyPageMain>
+  );
 }
 
 export default MyFollowing;

--- a/front/src/pages/myPages/MyFollowing.jsx
+++ b/front/src/pages/myPages/MyFollowing.jsx
@@ -4,7 +4,7 @@ import followDataApi from '../../api/followDataApi';
 import FollowList from '../../component/follow/FollowList';
 
 const MyPageMain = styled.main`
-  padding-top: 20rem;
+  padding-top: 22rem;
   max-width: 172rem;
   margin: 0 3rem;
   width: 90%;

--- a/front/src/pages/myPages/MyFollowing.jsx
+++ b/front/src/pages/myPages/MyFollowing.jsx
@@ -4,7 +4,7 @@ import followDataApi from '../../api/followDataApi';
 import FollowList from '../../component/follow/FollowList';
 
 const MyPageMain = styled.main`
-  padding-top: 23rem;
+  padding-top: 20rem;
   max-width: 172rem;
   margin: 0 3rem;
   @media screen and (max-width: 549px) {

--- a/front/src/pages/myPages/MyFollowing.jsx
+++ b/front/src/pages/myPages/MyFollowing.jsx
@@ -7,6 +7,10 @@ const MyPageMain = styled.main`
   padding-top: 23rem;
   max-width: 172rem;
   margin: 0 3rem;
+  @media screen and (max-width: 549px) {
+    padding-top: 15rem;
+    margin: 0 1rem;
+  }
 `;
 
 function MyFollowing() {

--- a/front/src/pages/myPages/MyLikes.jsx
+++ b/front/src/pages/myPages/MyLikes.jsx
@@ -11,6 +11,7 @@ const MyPageMain = styled.main`
   margin: 0 3rem;
   display: flex;
   flex-wrap: wrap;
+  width: 100%;
 
   .target {
     width: 100%;
@@ -56,7 +57,7 @@ function MyLikes() {
   const [myLike, setMyLike] = useState([]);
   const [isPending, setIsPending] = useState(false);
   const accountId = getCookie('accountId');
-  const target = useIntersect(
+  const [target] = useIntersect(
     `/boards/like/account/${accountId}?`,
     20,
     setMyLike,

--- a/front/src/pages/myPages/MyPage.jsx
+++ b/front/src/pages/myPages/MyPage.jsx
@@ -12,7 +12,7 @@ const MyPageWrapper = styled.div`
 
 function MyPage() {
   return (
-    <MyPageWrapper className="mypagewrapper">
+    <MyPageWrapper>
       <UserInfo />
       <Outlet />
     </MyPageWrapper>

--- a/front/src/pages/myPages/MyPost.jsx
+++ b/front/src/pages/myPages/MyPost.jsx
@@ -11,6 +11,7 @@ const MyPageMain = styled.main`
   margin: 0 3rem;
   display: flex;
   flex-wrap: wrap;
+  width: 100%;
 
   .target {
     width: 100%;
@@ -56,7 +57,7 @@ function MyPost() {
   const [myPost, setMyPost] = useState([]);
   const [isPending, setIsPending] = useState(false);
   const accountId = getCookie('accountId');
-  const target = useIntersect(
+  const [target] = useIntersect(
     `/boards/account/${accountId}?`,
     15,
     setMyPost,


### PR DESCRIPTION
css는 아까 회의시간에 보여드린 것에서 수정하지 않았습니다.
360px 이하로 내려가면 유저프로필만 나오게 해보려했는데, 유저 프로필에 center 가 안먹어서 이것 저것 시도해보았습니다만 잘 안풀려서, 우선 이대로 마무리하고, 지금 급한 회원가입 약관, 로그인모달, 로그아웃 문제를 해결해야 할 것 같습니다.
기본적인 반응형과, props와 컴포넌트간 연결, 팔로우 팔로잉 버튼은 마무리 해놓았습니다.
아래에 완성도를 높이기위해 해야할 목록 적어놓았습니다. 

Todo
1. 반응형 360px 이하로 내려가면 유저프로필만 나오게 하는 부분,
2. 타회원정보 페이지 추가되면 유저 카드 눌렀을 때, 해당 유저페이지로 이동되게 하는 부분,
3. 팔로우 팔로잉 탭에서 언팔하거나 팔로우하면 현재는 리로딩되면서 데이터 갱신과 함께 리랜더링이 이루어지는데,
리로드 없이 리랜더링을 할 수 있는 방법이 있다면 해당 방법 적용.

