### PR TITLE
[Feat] 내정보 수정 화면 제작

### DIFF
--- a/front/src/App.js
+++ b/front/src/App.js
@@ -18,6 +18,7 @@ import MyLikes from './pages/myPages/MyLikes';
 import MyFollower from './pages/myPages/MyFollower';
 import MyFollowing from './pages/myPages/MyFollowing';
 import MainPage from './pages/mainPages/MainPage';
+import MyInfoEdit from './pages/myPages/MyInfoEdit';
 
 const PublishPage = React.lazy(() => import('./pages/PublishPage'));
 const PostDetailPage = React.lazy(() => import('./pages/PostDetailPage'));
@@ -76,6 +77,7 @@ function App() {
             <Route path="myfollower" element={<MyFollower />} />
             <Route path="myfollowing" element={<MyFollowing />} />
           </Route>
+          <Route path="/myinfoedit" element={<MyInfoEdit />} />
         </Routes>
       </Suspense>
     </Router>

--- a/front/src/api/myInfoEditApi.js
+++ b/front/src/api/myInfoEditApi.js
@@ -1,0 +1,15 @@
+import axios from 'axios';
+import { getCookie } from '../util/cookie';
+
+const myInfoEditApi = formData => {
+  const jwt = getCookie('accessToken');
+
+  return axios.post('/accounts/modify', JSON.stringify(formData), {
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: jwt,
+    },
+  });
+};
+
+export default myInfoEditApi;

--- a/front/src/component/myInfoEdit/MyInfoEditContent.jsx
+++ b/front/src/component/myInfoEdit/MyInfoEditContent.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+function MyInfoEditContent() {
+  return <div>MyInfoEditContent</div>;
+}
+
+export default MyInfoEditContent;

--- a/front/src/component/myInfoEdit/MyInfoEditContent.jsx
+++ b/front/src/component/myInfoEdit/MyInfoEditContent.jsx
@@ -1,7 +1,236 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import styled from 'styled-components';
+import { useNavigate } from 'react-router-dom';
+import userDataApi from '../../api/userDataApi';
+import { DefaultButton, TransparentButton } from '../common/button/ButtonStyle';
+import myInfoEditApi from '../../api/myInfoEditApi';
 
-function MyInfoEditContent() {
-  return <div>MyInfoEditContent</div>;
+const Container = styled.div``;
+
+const SectionContent = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 30rem;
+  gap: 5rem 0;
+  @media screen and (max-width: 549px) {
+    justify-content: center;
+    width: 80vw;
+  }
+`;
+
+const Item = styled(SectionContent)`
+  flex-direction: row;
+  justify-content: start;
+  @media screen and (max-width: 549px) {
+    justify-content: center;
+  }
+`;
+
+const InputContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+`;
+
+const Input = styled.input`
+  border: none;
+  border-bottom: 1px solid var(--holder-base-color);
+  outline: 0;
+  width: 20rem;
+  ::placeholder {
+    color: var(--holder-base-color);
+  }
+  &:focus {
+    border-color: var(--button-theme);
+  }
+  @media screen and (max-width: 549px) {
+    width: 50vw;
+    min-width: 40vw;
+  }
+`;
+
+const Label = styled.label`
+  display: flex;
+  margin-right: 2rem;
+`;
+
+const ButtonGroup = styled.div`
+  display: flex;
+  justify-content: end;
+  width: 100%;
+  margin-top: 6rem;
+`;
+
+const SubmitButton = styled(DefaultButton)`
+  &:disabled {
+    background-color: var(--holder-base-color);
+    color: var(--font-base-grey);
+  }
+`;
+const CancelButton = styled(TransparentButton)``;
+
+const ErrorMsg = styled.span`
+  color: red;
+  font-size: 1rem;
+`;
+
+function MyInfoEditContent({ formData, setFormData }) {
+  const navigate = useNavigate();
+  const [nicknameError, setNicknameError] = useState(false);
+  const [passwordError, setPasswordError] = useState(false);
+  const [errorMessage, setErrorMessage] = useState({
+    nickname: '',
+    password: '',
+  });
+
+  const onChange = event => {
+    const InputName = event.target.name;
+    const InputValue = event.target.value;
+    const InputLength = InputValue.length;
+
+    if (InputName === 'nickname') {
+      if (InputLength === 0) {
+        setErrorMessage(prev => ({
+          ...prev,
+          nickname: '1글자 이상 입력하세요',
+        }));
+        setNicknameError(true);
+      } else setNicknameError(false);
+    }
+    if (InputName === 'password') {
+      if (InputLength < 8) {
+        setErrorMessage(prev => ({
+          ...prev,
+          password: '8글자 이상 입력하세요',
+        }));
+        setPasswordError(true);
+      } else setPasswordError(false);
+    }
+
+    setFormData({ ...formData, [event.target.name]: event.target.value });
+  };
+
+  const editRequest = event => {
+    event.preventDefault();
+    /* eslint-disable */
+    if (formData.nickname === defaultNickname) delete formData.nickname;
+
+    myInfoEditApi(formData)
+      .then(res => {
+        if (res.status === 200) {
+          alert('editted');
+        }
+      })
+      .catch(error => {
+        console.log(error.response.data.message);
+        if (error.response.data.code === '014') {
+          setErrorMessage(prev => ({
+            ...prev,
+            nickname: error.response.data.message,
+          }));
+          setNicknameError(true);
+        }
+      });
+  };
+
+  // 닉네임을 변경하지 않고 제출할때 서버의 닉네임 중복검사 테스트를 통과시키기 위한 목적
+  const [defaultNickname, setDefaultNickname] = useState();
+
+  useEffect(() => {
+    userDataApi()
+      .then(res => {
+        setFormData({
+          password: res.data.password,
+          nickname: res.data.nickname,
+          intro: res.data.intro,
+          profile: res.data.profile,
+        });
+        setDefaultNickname(res.data.nickname);
+      })
+      .catch(err => console.log(err));
+  }, []);
+
+  return (
+    <Container>
+      <SectionContent>
+        <Item>
+          <Label htmlFor="nickname">닉네임</Label>
+          <InputContainer>
+            <Input
+              id="nickname"
+              name="nickname"
+              type="text"
+              defaultValue={defaultNickname}
+              onChange={event => {
+                onChange(event);
+              }}
+              maxLength={20}
+            />
+            {nicknameError ? (
+              <ErrorMsg>{errorMessage.nickname}</ErrorMsg>
+            ) : null}
+          </InputContainer>
+        </Item>
+        <Item>
+          <Label htmlFor="password">비밀번호</Label>
+          <InputContainer>
+            <Input
+              id="password"
+              name="password"
+              type="password"
+              placeholder="변경할 비밀번호를 입력하세요"
+              onChange={event => {
+                onChange(event);
+              }}
+              minLength={8}
+            />
+            {passwordError ? (
+              <ErrorMsg>{errorMessage.password}</ErrorMsg>
+            ) : null}
+          </InputContainer>
+        </Item>
+        <Item>
+          <Label htmlFor="intro">자기소개</Label>
+          <InputContainer>
+            <Input
+              id="intro"
+              name="intro"
+              type="text"
+              placeholder={
+                formData.intro.length === 0
+                  ? '자기소개를 입력해주세요'
+                  : formData.intro
+              }
+              defaultValue={formData.intro}
+              onChange={event => {
+                onChange(event);
+              }}
+              maxLength={30}
+            />
+          </InputContainer>
+        </Item>
+      </SectionContent>
+      <ButtonGroup>
+        <SubmitButton
+          width="75px"
+          height="35px"
+          onClick={editRequest}
+          disabled={nicknameError || passwordError}
+        >
+          적용
+        </SubmitButton>
+        <CancelButton
+          width="75px"
+          height="35px"
+          onClick={() => {
+            navigate('/mypage');
+          }}
+        >
+          취소
+        </CancelButton>
+      </ButtonGroup>
+    </Container>
+  );
 }
 
 export default MyInfoEditContent;

--- a/front/src/component/myInfoEdit/MyInfoEditContent.jsx
+++ b/front/src/component/myInfoEdit/MyInfoEditContent.jsx
@@ -91,7 +91,7 @@ function MyInfoEditContent({ formData, setFormData }) {
 
   const onChange = event => {
     const InputName = event.target.name;
-    const InputValue = event.target.value;
+    const InputValue = event.target.value.trim();
     const InputLength = InputValue.length;
 
     if (InputName === 'nickname') {
@@ -113,7 +113,10 @@ function MyInfoEditContent({ formData, setFormData }) {
       } else setPasswordError(false);
     }
 
-    setFormData({ ...formData, [event.target.name]: event.target.value });
+    setFormData({
+      ...formData,
+      [InputName]: InputValue,
+    });
   };
 
   const editRequest = event => {
@@ -157,6 +160,7 @@ function MyInfoEditContent({ formData, setFormData }) {
         setDefaultNickname(res.data.nickname);
       })
       .catch(err => console.log(err));
+    return () => {};
   }, []);
 
   return (
@@ -206,7 +210,7 @@ function MyInfoEditContent({ formData, setFormData }) {
               name="intro"
               type="text"
               placeholder={
-                formData.intro.length === 0
+                formData.intro === ''
                   ? '자기소개를 입력해주세요'
                   : formData.intro
               }

--- a/front/src/component/myInfoEdit/MyInfoEditContent.jsx
+++ b/front/src/component/myInfoEdit/MyInfoEditContent.jsx
@@ -4,6 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import userDataApi from '../../api/userDataApi';
 import { DefaultButton, TransparentButton } from '../common/button/ButtonStyle';
 import myInfoEditApi from '../../api/myInfoEditApi';
+import ConfirmModal from '../common/modal/ConfirmModal';
 
 const Container = styled.div``;
 
@@ -82,6 +83,11 @@ function MyInfoEditContent({ formData, setFormData }) {
     nickname: '',
     password: '',
   });
+  const [confirmModalOpened, setConfirmModalOpened] = useState(false);
+
+  const confirmModalCloser = () => {
+    setConfirmModalOpened(false);
+  };
 
   const onChange = event => {
     const InputName = event.target.name;
@@ -118,7 +124,10 @@ function MyInfoEditContent({ formData, setFormData }) {
     myInfoEditApi(formData)
       .then(res => {
         if (res.status === 200) {
-          alert('editted');
+          setConfirmModalOpened(true);
+          setTimeout(() => {
+            navigate('/mypage');
+          }, 1000);
         }
       })
       .catch(error => {
@@ -229,6 +238,12 @@ function MyInfoEditContent({ formData, setFormData }) {
           취소
         </CancelButton>
       </ButtonGroup>
+      {confirmModalOpened ? (
+        <ConfirmModal
+          modalMessage={'프로필 수정이 완료되었습니다.'}
+          modalCloser={confirmModalCloser}
+        />
+      ) : null}
     </Container>
   );
 }

--- a/front/src/component/myInfoEdit/MyInfoEditForm.jsx
+++ b/front/src/component/myInfoEdit/MyInfoEditForm.jsx
@@ -10,7 +10,7 @@ const Container = styled.div`
   width: 100vw;
   font-size: 1.5rem;
   color: var(--font-base-grey);
-  margin-top: 8rem;
+  margin-top: 10vh;
   @media screen and (max-width: 549px) {
     flex-direction: column;
     margin-top: 4rem;

--- a/front/src/component/myInfoEdit/MyInfoEditForm.jsx
+++ b/front/src/component/myInfoEdit/MyInfoEditForm.jsx
@@ -13,8 +13,7 @@ const Container = styled.div`
   margin-top: 8rem;
   @media screen and (max-width: 549px) {
     flex-direction: column;
-    margin-top: 3em;
-    padding: 0 5vw;
+    margin-top: 4rem;
   }
 `;
 

--- a/front/src/component/myInfoEdit/MyInfoEditForm.jsx
+++ b/front/src/component/myInfoEdit/MyInfoEditForm.jsx
@@ -1,0 +1,37 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import MyInfoEditProfile from './MyInfoEditProfile';
+import MyInfoEditContent from './MyInfoEditContent';
+
+const Container = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100vw;
+  font-size: 1.5rem;
+  color: var(--font-base-grey);
+  margin-top: 8rem;
+  @media screen and (max-width: 549px) {
+    flex-direction: column;
+    margin-top: 3em;
+    padding: 0 5vw;
+  }
+`;
+
+function MyInfoEditForm() {
+  const [formData, setFormData] = useState({
+    password: '',
+    nickname: '',
+    intro: '',
+    profile: '',
+  });
+
+  return (
+    <Container>
+      <MyInfoEditProfile formData={formData} setFormData={setFormData} />
+      <MyInfoEditContent formData={formData} setFormData={setFormData} />
+    </Container>
+  );
+}
+
+export default MyInfoEditForm;

--- a/front/src/component/myInfoEdit/MyInfoEditProfile.jsx
+++ b/front/src/component/myInfoEdit/MyInfoEditProfile.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+function MyInfoEditProfile() {
+  return <div>MyInfoEditProfile</div>;
+}
+
+export default MyInfoEditProfile;

--- a/front/src/component/myInfoEdit/MyInfoEditProfile.jsx
+++ b/front/src/component/myInfoEdit/MyInfoEditProfile.jsx
@@ -35,7 +35,7 @@ const ProfileDefault = styled.div`
 
 const ProfilePreview = styled.img`
   ${ProfileStyle}
-  border:none;
+  border:0.5px solid var(--holder-base-color);
 `;
 
 const ProfileEdit = styled.label`
@@ -46,6 +46,13 @@ const ProfileEdit = styled.label`
   width: 4.5rem;
   height: 4.5rem;
   background-color: var(--base-white-color);
+  &:hover {
+    background-color: var(--font-base-grey);
+    transition: 0.2s all ease-in-out;
+  }
+  &:active {
+    scale: calc(0.9);
+  }
 `;
 
 const CameraIcon = styled(BsCamera)`

--- a/front/src/component/myInfoEdit/MyInfoEditProfile.jsx
+++ b/front/src/component/myInfoEdit/MyInfoEditProfile.jsx
@@ -1,7 +1,164 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import styled, { css } from 'styled-components';
+import { BsCamera, BsPerson } from 'react-icons/bs';
+import postPhotoApi from '../../api/postPhotoApi';
 
-function MyInfoEditProfile() {
-  return <div>MyInfoEditProfile</div>;
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const SectionProfile = styled.div`
+  position: relative;
+  text-align: center;
+  max-width: auto;
+  margin: 0 6rem;
+  margin-bottom: 9rem;
+  @media screen and (max-width: 549px) {
+    margin-bottom: 5rem;
+  }
+`;
+
+const ProfileStyle = css`
+  width: 15rem;
+  height: 15rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border: 1.5px solid var(--holder-base-color);
+  border-radius: 50%;
+`;
+
+const ProfileDefault = styled.div`
+  ${ProfileStyle}
+`;
+
+const ProfilePreview = styled.img`
+  ${ProfileStyle}
+  border:none;
+`;
+
+const ProfileEdit = styled.label`
+  ${ProfileStyle}
+  position:absolute;
+  bottom: 0;
+  right: 0;
+  width: 4.5rem;
+  height: 4.5rem;
+  background-color: var(--base-white-color);
+`;
+
+const CameraIcon = styled(BsCamera)`
+  font-size: 2.5rem;
+  color: var(--holder-base-color);
+`;
+
+const AvatarIcon = styled(BsPerson)`
+  width: 5rem;
+  height: 5rem;
+  color: var(--holder-base-color);
+`;
+
+const ProfileHidden = styled.input`
+  display: none;
+`;
+
+const ErrorMsg = styled.p`
+  color: red;
+  font-size: 1rem;
+  text-align: center;
+  margin-bottom: 5px;
+`;
+
+function MyInfoEditProfile({ formData, setFormData }) {
+  const [blob, setBlob] = useState(); // 이미지
+  const [previewUrl, setPreviewUrl] = useState(); // 미리보기 url 주소
+  const [resURL, setResURL] = useState(''); // 서버 저장 url 주소
+  const [errorMessage, setErrorMessage] = useState(''); // 용량 제한 메시지
+
+  const uploadImage = async event => {
+    setBlob(...event.target.files); // 이미지 등록
+  };
+
+  const validatePhotos = event => {
+    const targetFileSize = event.target.files[0].size; // 업로드 사진 크기 (단위:bytes)
+    const targetFileSizeToMb = targetFileSize / (1024 * 1024); // bytes=>megabyte 변환
+    const targetFileSizeToKb = targetFileSize / 1024; // b=>kilobyte 변환
+    const MAX_SIZE_MB = 3; // 최대 10mb <= 이 부분을 설정하시면 됩니다.
+    const MIN_SIZE_KB = 0; // 최소 0kb
+
+    if (targetFileSizeToMb > MAX_SIZE_MB) {
+      setErrorMessage(`${MAX_SIZE_MB}MB 미만의 사진을 업로드하세요.`);
+    } else if (targetFileSizeToKb < MIN_SIZE_KB) {
+      setErrorMessage(`최소 업로드 크기는 ${MIN_SIZE_KB}KB 입니다.`);
+    } else {
+      setErrorMessage('');
+      uploadImage(event); // 조건 통과시 상단의 미리보기 업로드 함수 실행
+    }
+  };
+
+  // 미리보기 렌더링
+  useEffect(() => {
+    const reader = new FileReader();
+    if (blob) {
+      reader.readAsDataURL(blob);
+      reader.onload = event => {
+        setPreviewUrl(event.target.result);
+      };
+    }
+  }, [blob]);
+
+  // 이미지 서버 전송
+  useEffect(() => {
+    const blobFormData = new FormData();
+    if (blob) {
+      blobFormData.append('images', blob);
+    }
+    try {
+      if (blob) {
+        postPhotoApi(blobFormData).then(res => {
+          setResURL(...res.data.imagePaths);
+        });
+      }
+    } catch (err) {
+      console.log(err);
+    }
+  }, [blob]);
+
+  /* eslint-disable */
+  const handleClick = event => {
+    event.target.value = ''; // 동일한 사진을 여러번 올릴수 있게 해줌
+  };
+
+  useEffect(() => {
+    setFormData({ ...formData, profile: resURL });
+  }, [resURL]);
+
+  return (
+    <Wrapper>
+      {!errorMessage.length ? null : <ErrorMsg>{errorMessage}</ErrorMsg>}
+      <SectionProfile>
+        <ProfileHidden
+          type="file"
+          id="profile"
+          name="profile"
+          onChange={validatePhotos}
+          onClick={handleClick}
+          accept="image/png, image/jpg, image/jpeg"
+        />
+        {previewUrl ? (
+          <ProfilePreview src={previewUrl} alt="preview" />
+        ) : (
+          <ProfileDefault>
+            <AvatarIcon />
+          </ProfileDefault>
+        )}
+        <ProfileEdit htmlFor="profile">
+          <CameraIcon />
+        </ProfileEdit>
+      </SectionProfile>
+    </Wrapper>
+  );
 }
 
 export default MyInfoEditProfile;

--- a/front/src/component/myInfoEdit/MyInfoEditProfile.jsx
+++ b/front/src/component/myInfoEdit/MyInfoEditProfile.jsx
@@ -11,7 +11,6 @@ const Wrapper = styled.div`
 const SectionProfile = styled.div`
   position: relative;
   text-align: center;
-  max-width: auto;
   margin: 0 6rem;
   margin-bottom: 9rem;
   @media screen and (max-width: 549px) {
@@ -91,7 +90,7 @@ function MyInfoEditProfile({ formData, setFormData }) {
     const targetFileSize = event.target.files[0].size; // 업로드 사진 크기 (단위:bytes)
     const targetFileSizeToMb = targetFileSize / (1024 * 1024); // bytes=>megabyte 변환
     const targetFileSizeToKb = targetFileSize / 1024; // b=>kilobyte 변환
-    const MAX_SIZE_MB = 3; // 최대 10mb <= 이 부분을 설정하시면 됩니다.
+    const MAX_SIZE_MB = 3; // 최대 3mb
     const MIN_SIZE_KB = 0; // 최소 0kb
 
     if (targetFileSizeToMb > MAX_SIZE_MB) {

--- a/front/src/component/userInfo/UserInfoCard.jsx
+++ b/front/src/component/userInfo/UserInfoCard.jsx
@@ -55,7 +55,7 @@ function UserInfoCard({ userdata }) {
         <UserInfoText>
           <div>
             <h1>{userdata.nickname}</h1>
-            <EditButton to="#">내 정보수정</EditButton>
+            <EditButton to="/myinfoedit">내 정보수정</EditButton>
           </div>
           <h5>{userdata.email}</h5>
           <p>{userdata.intro}</p>

--- a/front/src/pages/myPages/MyInfoEdit.jsx
+++ b/front/src/pages/myPages/MyInfoEdit.jsx
@@ -5,6 +5,9 @@ import UserInfo from '../../component/userInfo/UserInfo';
 const WrapperUserInfo = styled.div`
   padding-top: 8rem;
   padding-bottom: 20rem;
+  @media screen and (max-width: 549px) {
+    padding-bottom: 14rem;
+  }
 `;
 
 function MyInfoEdit() {

--- a/front/src/pages/myPages/MyInfoEdit.jsx
+++ b/front/src/pages/myPages/MyInfoEdit.jsx
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import MyInfoEditForm from '../../component/myInfoEdit/MyInfoEditForm';
 import UserInfo from '../../component/userInfo/UserInfo';
 
 const WrapperUserInfo = styled.div`
@@ -8,9 +9,12 @@ const WrapperUserInfo = styled.div`
 
 function MyInfoEdit() {
   return (
-    <WrapperUserInfo>
-      <UserInfo />
-    </WrapperUserInfo>
+    <>
+      <WrapperUserInfo>
+        <UserInfo />
+      </WrapperUserInfo>
+      <MyInfoEditForm />
+    </>
   );
 }
 

--- a/front/src/pages/myPages/MyInfoEdit.jsx
+++ b/front/src/pages/myPages/MyInfoEdit.jsx
@@ -1,0 +1,17 @@
+import styled from 'styled-components';
+import UserInfo from '../../component/userInfo/UserInfo';
+
+const WrapperUserInfo = styled.div`
+  padding-top: 8rem;
+  padding-bottom: 20rem;
+`;
+
+function MyInfoEdit() {
+  return (
+    <WrapperUserInfo>
+      <UserInfo />
+    </WrapperUserInfo>
+  );
+}
+
+export default MyInfoEdit;


### PR DESCRIPTION
### 작업내역
- 프로필사진, 닉네임(중복값 검사 포함), 비밀번호, 자기소개 수정
- 사진은 계속 여러개 등록해도 가장 최근 것만 반영되고 카메라 아이콘이 등록버튼입니다.
- 수정하지 않고 등록한 항목은 기존 정보가 유지됩니다.
- 렌더링은 createObjectURL말고 FileReader readAsDataURL 메서드 궁금해서 사용해봤습니다.
- 느린 대신 메모리 관리가 자동으로 된다는데 프로필은 사진 한장이라 체감은 크게 안되네요.

작동 안되는 부분 있으시면 알려주세요!

*Todo : 회원탈퇴버튼 추가