### PR TITLE
[Fix] 로그아웃 핸들러 버그 수정

### DIFF
--- a/front/src/component/common/header/HeaderDropDownItem.jsx
+++ b/front/src/component/common/header/HeaderDropDownItem.jsx
@@ -31,21 +31,14 @@ function HedaerDropDownItem({ linkText, link, activeHandler }) {
   const navigate = useNavigate();
 
   const cookieRemover = () => {
-    removeCookie('profile', {
+    const option = {
       path: '/',
       sameSite: 'None',
       secure: 'false',
-    });
-    removeCookie('accountId', {
-      path: '/',
-      sameSite: 'None',
-      secure: 'false',
-    });
-    removeCookie('accessToken', {
-      path: '/',
-      sameSite: 'None',
-      secure: 'false',
-    });
+    };
+    removeCookie('profile', option);
+    removeCookie('accountId', option);
+    removeCookie('accessToken', option);
   };
   // 로그아웃 핸들러
   const logoutHandler = () => {

--- a/front/src/component/common/header/HeaderDropDownItem.jsx
+++ b/front/src/component/common/header/HeaderDropDownItem.jsx
@@ -1,5 +1,7 @@
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
+import { useDispatch } from 'react-redux';
+import { loginActions } from '../../../redux/loginSlice';
 import { removeCookie } from '../../../util/cookie';
 
 const ItemWrapper = styled.li`
@@ -25,17 +27,31 @@ const ItemWrapper = styled.li`
 `;
 
 function HedaerDropDownItem({ linkText, link, activeHandler }) {
+  const dispatch = useDispatch();
+  const navigate = useNavigate();
+
+  const cookieRemover = () => {
+    removeCookie('profile', {
+      path: '/',
+      sameSite: 'None',
+      secure: 'false',
+    });
+    removeCookie('accountId', {
+      path: '/',
+      sameSite: 'None',
+      secure: 'false',
+    });
+    removeCookie('accessToken', {
+      path: '/',
+      sameSite: 'None',
+      secure: 'false',
+    });
+  };
   // 로그아웃 핸들러
   const logoutHandler = () => {
-    console.log('로그아웃 핸들러 앞');
-    removeCookie('profile');
-    removeCookie('accountId');
-    removeCookie('accessToken');
-    console.log('로그아웃 핸들러 중간');
-    setTimeout(() => {
-      window.location.href = '/';
-    }, 500);
-    console.log('로그아웃 핸들러 끝');
+    cookieRemover();
+    dispatch(loginActions.logout());
+    navigate('/');
   };
 
   return (


### PR DESCRIPTION
로그아웃 핸들러 버그 수정
removeCookie에 옵션 넣었습니다. 이것때문일지도 모른다고 생각해서요.
쿠키 삭제 후 리로딩이 되는 것이 아니고, dipatch를 통해 로그아웃 상태를 갱신시켜준 뒤, navigate를 통해 메인으로 이동시켰습니다.

일단 버그의 원인으로 의심되는 것은 위 두 가지 였고, 제가 테스트 했을 때엔 문제 없었습니다.
로그인 후, 마이페이지나 다른 페이지 들어가보신 다음, 새로고침 누르시고 이것저것 다른 동작도 해보신 뒤에, 로그아웃이 정상적으로 된다면 문제가 없는 것으로 간주해도 될 것 같습니다.