### PR TITLE
[Refactor] Post의 태그를 모두 보여주도록 수정

### DIFF
--- a/front/src/component/common/Post.jsx
+++ b/front/src/component/common/Post.jsx
@@ -48,7 +48,7 @@ const PostWrapper = styled.div`
         display: flex;
         justify-content: space-between;
         align-items: center;
-        padding: 5px 0 1rem;
+        padding-bottom: 1rem;
 
         .post__title {
           text-align: left;
@@ -90,34 +90,27 @@ const PostWrapper = styled.div`
         flex-direction: column;
 
         .post__tags {
-          display: flex;
-          justify-content: flex-start;
-          align-items: center;
+          height: 4rem;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          display: -webkit-box;
+          -webkit-line-clamp: 2;
+          -webkit-box-orient: vertical;
+          word-break: break-all;
 
           .post__tag {
+            display: inline;
             padding-right: 1rem;
             text-align: left;
             color: var(--font-tag-color);
             font-size: 1.3rem;
-            overflow: hidden;
-            text-overflow: ellipsis;
-            display: -webkit-box;
-            -webkit-line-clamp: 1;
-            -webkit-box-orient: vertical;
-            word-break: break-all;
-
-            @media screen and (max-width: 1621px) {
-              &:nth-child(3) {
-                display: none;
-              }
-            }
           }
         }
         .post__info {
           display: flex;
           justify-content: flex-end;
           align-items: center;
-          padding: 1rem 0 5px;
+          padding: 5px 0;
 
           .post__avatar {
             display: block;
@@ -168,13 +161,11 @@ function Post({ post }) {
           <div className="post__tw">
             {/* tag && user */}
             <ul className="post__tags">
-              {post.tags.map((tag, idx) => {
-                return idx < 3 ? (
-                  <li key={uuid()} className="post__tag">
-                    #{tag}
-                  </li>
-                ) : null;
-              })}
+              {post.tags.map(tag => (
+                <li key={uuid()} className="post__tag">
+                  #{tag}
+                </li>
+              ))}
             </ul>
             <div className="post__info">
               <span className="post__avatar">

--- a/front/src/component/common/Post.jsx
+++ b/front/src/component/common/Post.jsx
@@ -104,6 +104,7 @@ const PostWrapper = styled.div`
             text-align: left;
             color: var(--font-tag-color);
             font-size: 1.3rem;
+            line-height: 1.5;
           }
         }
         .post__info {

--- a/front/src/component/main/MainSort.jsx
+++ b/front/src/component/main/MainSort.jsx
@@ -56,7 +56,7 @@ function MainSort({ sort, sortHandler }) {
       <ul className="main__sortbar">
         <li>
           <button
-            className={sort === 'createdAt,desc' && 'sort__active'}
+            className={sort === 'createdAt,desc' ? 'sort__active' : undefined}
             onClick={() => {
               if (sort !== 'createdAt,desc') {
                 sortHandler('createdAt,desc');
@@ -68,7 +68,7 @@ function MainSort({ sort, sortHandler }) {
         </li>
         <li>
           <button
-            className={sort === 'likeCount,desc' && 'sort__active'}
+            className={sort === 'likeCount,desc' ? 'sort__active' : undefined}
             onClick={() => {
               if (sort !== 'likeCount,desc') {
                 sortHandler('likeCount,desc');
@@ -80,7 +80,7 @@ function MainSort({ sort, sortHandler }) {
         </li>
         <li>
           <button
-            className={sort === 'views,desc' && 'sort__active'}
+            className={sort === 'views,desc' ? 'sort__active' : undefined}
             onClick={() => {
               if (sort !== 'views,desc') {
                 sortHandler('views,desc');


### PR DESCRIPTION
기존에는 최대 3개까지 태그를 표시하도록 하였으나 등록된 태그를 모두 표시하도록 수정하였습니다.
Post의 크기가 줄어 태그를 모두 표시하지 못할 경우 마지막 태그부터 말줄임 되도록 하였습니다.
