### PR TITLE
[Fix] Image validation 추가

### DIFF
--- a/back/src/main/java/travelRepo/domain/board/dto/BoardAddReq.java
+++ b/back/src/main/java/travelRepo/domain/board/dto/BoardAddReq.java
@@ -17,7 +17,7 @@ public class BoardAddReq {
     private String title;
 
     @NotNull
-    @Length(min = 5)
+    @Length(min = 5, max = 2000)
     private String content;
 
     private String location;

--- a/back/src/main/java/travelRepo/domain/board/dto/BoardModifyReq.java
+++ b/back/src/main/java/travelRepo/domain/board/dto/BoardModifyReq.java
@@ -13,7 +13,7 @@ public class BoardModifyReq {
     @Length(min = 5, max = 40)
     private String title;
 
-    @Length(min = 5)
+    @Length(min = 5, max = 2000)
     private String content;
 
     private String location;

--- a/back/src/main/java/travelRepo/global/exception/ExceptionCode.java
+++ b/back/src/main/java/travelRepo/global/exception/ExceptionCode.java
@@ -20,7 +20,8 @@ public enum ExceptionCode {
     MAIL_SEND_FAILED(500, "이메일 전송이 실패했습니다.", "012"),
     TEMP_PASSWORD_DELAY(400, "임시 비밀번호 발급은 1시간에 한번 가능합니다.", "013"),
     DUPLICATION_NICKNAME(400, "동일한 닉네임의 계정이 존재합니다.", "014"),
-    EMPTY_FILE(400, "파일이 비어있습니다.", "015");
+    EMPTY_FILE(400, "파일이 비어있습니다.", "015"),
+    ILLEGAL_FILENAME(400, "잘못된 형식의 파일 이름입니다.", "016");
 
     private int status;
 

--- a/back/src/main/java/travelRepo/global/image/service/ImageService.java
+++ b/back/src/main/java/travelRepo/global/image/service/ImageService.java
@@ -19,9 +19,7 @@ public class ImageService {
 
     public String uploadImage(MultipartFile image, String path) {
 
-        if (image == null || image.isEmpty()) {
-            throw new BusinessLogicException(ExceptionCode.EMPTY_FILE);
-        }
+        validationImage(image);
 
         try {
             return imageRepository.save(image, path);
@@ -35,5 +33,23 @@ public class ImageService {
         return images.stream()
                 .map(image -> uploadImage(image, path))
                 .collect(Collectors.toList());
+    }
+
+    public void validationImage(MultipartFile image) {
+
+        if (image == null || image.isEmpty()) {
+            throw new BusinessLogicException(ExceptionCode.EMPTY_FILE);
+        }
+
+        String imageName = image.getOriginalFilename();
+
+        if (imageName == null) {
+            throw new BusinessLogicException(ExceptionCode.ILLEGAL_FILENAME);
+        }
+
+        boolean matches = imageName.matches("^\\S.*\\.(jpg|JPG|jpeg|JPEG|png|PNG)$");
+        if (!matches) {
+            throw new BusinessLogicException(ExceptionCode.ILLEGAL_FILENAME);
+        }
     }
 }

--- a/back/src/test/java/travelRepo/global/image/controller/ImageControllerTest.java
+++ b/back/src/test/java/travelRepo/global/image/controller/ImageControllerTest.java
@@ -13,10 +13,13 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;import org.springframework.transaction.annotation.Transactional;
 import travelRepo.domain.account.entity.Account;
 import travelRepo.domain.account.repository.AccountRepository;
+import travelRepo.global.exception.BusinessLogicException;
+import travelRepo.global.exception.ExceptionCode;
 import travelRepo.global.security.authentication.UserAccount;
 import travelRepo.global.security.jwt.JwtProcessor;
 import travelRepo.util.After;
 
+import java.net.BindException;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -28,6 +31,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWit
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static travelRepo.util.ApiDocumentUtils.getRequestPreProcessor;
 import static travelRepo.util.ApiDocumentUtils.getResponsePreProcessor;
@@ -59,11 +63,11 @@ class ImageControllerTest extends After {
         Account account = accountRepository.findById(accountId).get();
         String jwt = "Bearer " + jwtProcessor.createAuthJwtToken(new UserAccount(account));
 
-        MockMultipartFile image1 = new MockMultipartFile("images", "image1.jpeg", "image/jpeg",
+        MockMultipartFile image1 = new MockMultipartFile("images", "이것은 이미지 파일 입니다..jpeg", "image/jpeg",
                 "(file data)".getBytes());
-        MockMultipartFile image2 = new MockMultipartFile("images", "image2.jpeg", "image/jpeg",
+        MockMultipartFile image2 = new MockMultipartFile("images", "abcd1234.가나다ㄱㄴㅏㅗ!@#$[]:;'=+-_(){}.jpg", "image/jpg",
                 "(file data)".getBytes());
-        MockMultipartFile image3 = new MockMultipartFile("images", "image3.jpeg", "image/jpeg",
+        MockMultipartFile image3 = new MockMultipartFile("images", "this1. is2. image3.png", "image/png",
                 "(file data)".getBytes());
 
         //when
@@ -72,9 +76,7 @@ class ImageControllerTest extends After {
                         .file(image1)
                         .file(image2)
                         .file(image3)
-                        .header("Authorization", jwt)
-
-        );
+                        .header("Authorization", jwt));
 
         //then
         actions
@@ -99,5 +101,91 @@ class ImageControllerTest extends After {
                                 )
                         )
                 ));
+    }
+
+    @Test
+    @DisplayName("이미지 저장_비어있는 요청")
+    void ImageUpload_EmptyRequest() throws Exception {
+
+        //given
+        Long accountId = 10001L;
+        Account account = accountRepository.findById(accountId).get();
+        String jwt = "Bearer " + jwtProcessor.createAuthJwtToken(new UserAccount(account));
+
+        //when
+        ResultActions actions = mockMvc.perform(
+                multipart("/image-files")
+                        .header("Authorization", jwt));
+
+        //then
+        actions
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.exception").value(BindException.class.getSimpleName()))
+                .andExpect(jsonPath("$.message").value(ExceptionCode.BIND_EXCEPTION.getMessage()));
+    }
+
+    @Test
+    @DisplayName("이미지 저장_잘못된 파일 형식")
+    void ImageUpload_IllegalFile() throws Exception {
+
+        //given
+        Long accountId = 10001L;
+        Account account = accountRepository.findById(accountId).get();
+        String jwt = "Bearer " + jwtProcessor.createAuthJwtToken(new UserAccount(account));
+
+        MockMultipartFile emptyFile = new MockMultipartFile("images", "image3.png", "image/png",
+                "".getBytes());
+        MockMultipartFile illegalFilename = new MockMultipartFile("images", "image1.gif", "image/jpeg",
+                "(file data)".getBytes());
+        MockMultipartFile emptyFilename = new MockMultipartFile("images", "", "image/jpg",
+                "(file data)".getBytes());
+        MockMultipartFile blankFilename = new MockMultipartFile("images", "  .jpg", "image/png",
+                "(file data)".getBytes());
+        MockMultipartFile blankOriginalFilename = new MockMultipartFile("images", "   ", "image/png",
+                "(file data)".getBytes());
+
+        //when
+        ResultActions emptyFileAction = mockMvc.perform(
+                multipart("/image-files")
+                        .file(emptyFile)
+                        .header("Authorization", jwt));
+        ResultActions illegalFilenameAction = mockMvc.perform(
+                multipart("/image-files")
+                        .file(illegalFilename)
+                        .header("Authorization", jwt));
+        ResultActions emptyFilenameAction = mockMvc.perform(
+                multipart("/image-files")
+                        .file(emptyFilename)
+                        .header("Authorization", jwt));
+        ResultActions blankFilenameAction = mockMvc.perform(
+                multipart("/image-files")
+                        .file(blankFilename)
+                        .header("Authorization", jwt));
+        ResultActions blankOriginalFilenameAction = mockMvc.perform(
+                multipart("/image-files")
+                        .file(blankOriginalFilename)
+                        .header("Authorization", jwt));
+
+        //then
+        emptyFileAction
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.exception").value(BusinessLogicException.class.getSimpleName()))
+                .andExpect(jsonPath("$.message").value(ExceptionCode.EMPTY_FILE.getMessage()));
+        illegalFilenameAction
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.exception").value(BusinessLogicException.class.getSimpleName()))
+                .andExpect(jsonPath("$.message").value(ExceptionCode.ILLEGAL_FILENAME.getMessage()));
+        emptyFilenameAction
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.exception").value(BusinessLogicException.class.getSimpleName()))
+                .andExpect(jsonPath("$.message").value(ExceptionCode.ILLEGAL_FILENAME.getMessage()));
+        blankFilenameAction
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.exception").value(BusinessLogicException.class.getSimpleName()))
+                .andExpect(jsonPath("$.message").value(ExceptionCode.ILLEGAL_FILENAME.getMessage()));
+        blankOriginalFilenameAction
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.exception").value(BusinessLogicException.class.getSimpleName()))
+                .andExpect(jsonPath("$.message").value(ExceptionCode.ILLEGAL_FILENAME.getMessage()));
     }
 }


### PR DESCRIPTION
Image validation을 추가하였고 그에 따른 테스트도 추가하였습니다.

jpg, jpeg, png의 확장자만 받을 수 있도록 변경하였습니다.
확장자를 제외한 파일이름의 형식에도 제한을 걸어놨습니다.
파일 이름은 공백으로만 이루어지는 경우만을 제한하였습니다.
ex) "    .jpg"

추가 변경
1. 프런트와 맞춰 board의 content의 최대 자수를 2000자로 제한 하였습니다. 
: boardAddReq, boardModifyReq에 적용하였습니다.