### PR TITLE
[Refactor] cacheEvent 구조 변경

### DIFF
--- a/back/src/main/java/travelRepo/domain/account/dto/FollowAccountDetailsRes.java
+++ b/back/src/main/java/travelRepo/domain/account/dto/FollowAccountDetailsRes.java
@@ -6,8 +6,6 @@ import travelRepo.domain.board.dto.FollowBoardDetailsRes;
 import travelRepo.domain.board.entity.Board;
 
 import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 
 @Data
@@ -33,7 +31,7 @@ public class FollowAccountDetailsRes {
         List<Board> accountBoards = account.getBoards();
 
         accountBoards.sort((a, b) -> a.getCreatedAt().isAfter(b.getCreatedAt()) ? -1 : 1);
-        int size = Math.min(5, accountBoards.size());
+        int size = Math.min(6, accountBoards.size());
         for (int i = 0; i < size; i++) {
             Board board = accountBoards.get(i);
             followAccountDetailsRes.getBoards().add(FollowBoardDetailsRes.of(board));

--- a/back/src/main/java/travelRepo/domain/board/service/BoardService.java
+++ b/back/src/main/java/travelRepo/domain/board/service/BoardService.java
@@ -82,7 +82,7 @@ public class BoardService {
     }
 
     @Transactional
-    @CacheEvict(key = "#boardId", value = "{findBoard, boardView}")
+    @CacheEvict(key = "#boardId", value = {"findBoard", "boardView"})
     public void removeBoard(Long loginAccountId, Long boardId) {
 
         Board board = boardRepository.findByIdWithBoardTagsAndAccount(boardId)

--- a/back/src/main/java/travelRepo/global/cache/CacheConfig.java
+++ b/back/src/main/java/travelRepo/global/cache/CacheConfig.java
@@ -1,4 +1,4 @@
-package travelRepo.global.config;
+package travelRepo.global.cache;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.CacheManager;
@@ -23,7 +23,6 @@ import javax.annotation.PostConstruct;
 public class CacheConfig {
 
     public final RedisConnectionFactory connectionFactory;
-    public final Init init;
 
     @Bean
     public CacheManager redisCacheManager() {
@@ -40,27 +39,4 @@ public class CacheConfig {
                 .fromConnectionFactory(connectionFactory)
                 .cacheDefaults(redisCacheConfiguration).build();
     }
-
-    @PostConstruct
-    public void init() {
-        init.flushRedis();
-    }
-
-    @Component
-    @RequiredArgsConstructor
-    static class Init {
-
-        private final RedisTemplate<String, String> redisTemplate;
-
-        public void flushRedis() {
-            redisTemplate.execute(new RedisCallback<Object>() {
-                @Override
-                public Object doInRedis(RedisConnection connection) throws DataAccessException {
-                    connection.flushAll();
-                    return null;
-                }
-            });
-        }
-    }
-
 }

--- a/back/src/main/java/travelRepo/global/cache/CacheEvent.java
+++ b/back/src/main/java/travelRepo/global/cache/CacheEvent.java
@@ -1,0 +1,31 @@
+package travelRepo.global.cache;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.core.annotation.Order;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import travelRepo.domain.board.repository.BoardRepository;
+import travelRepo.global.cache.CacheProcessor;
+
+import javax.annotation.PostConstruct;
+
+@Component
+@RequiredArgsConstructor
+public class CacheEvent {
+
+    private final CacheProcessor cacheProcessor;
+
+    @PostConstruct
+    public void initCache() {
+        cacheProcessor.updateViewToMySql();
+        cacheProcessor.flushRedis();
+    }
+
+    @Scheduled(cron = "0 0 0/1 * * ?")
+    public void scheduleCache() {
+        cacheProcessor.updateViewToMySql();
+        cacheProcessor.flushRedis();
+    }
+
+}

--- a/back/src/main/java/travelRepo/global/cache/CacheProcessor.java
+++ b/back/src/main/java/travelRepo/global/cache/CacheProcessor.java
@@ -16,11 +16,10 @@ import java.util.Set;
 @RequiredArgsConstructor
 public class CacheProcessor {
 
-    RedisTemplate<String, String> redisTemplate;
-    BoardRepository boardRepository;
+    private final RedisTemplate<String, String> redisTemplate;
+    private final BoardRepository boardRepository;
 
     @Transactional
-    @Scheduled(cron = "0 0 0/1 * * ?")
     public void updateViewToMySql() {
 
         Set<String> keys = redisTemplate.keys("boardView*");
@@ -32,8 +31,6 @@ public class CacheProcessor {
             int views = Integer.parseInt(redisTemplate.opsForValue().get(key));
             boardRepository.updateViews(boardId, views);
         }
-
-        flushRedis();
     }
 
     public void flushRedis() {

--- a/back/src/test/java/travelRepo/domain/account/controller/AccountCacheTest.java
+++ b/back/src/test/java/travelRepo/domain/account/controller/AccountCacheTest.java
@@ -1,7 +1,6 @@
 package travelRepo.domain.account.controller;
 
 import com.google.gson.Gson;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -45,7 +44,7 @@ public class AccountCacheTest extends After {
     private JwtProcessor jwtProcessor;
 
     @Test
-    @DisplayName("회원 조회 캐싱_성공")
+    @DisplayName("회원 단일 조회 캐싱_성공")
     void accountAddCache_Success() throws Exception {
 
         //given

--- a/back/src/test/java/travelRepo/domain/account/controller/AccountCacheTest.java
+++ b/back/src/test/java/travelRepo/domain/account/controller/AccountCacheTest.java
@@ -1,0 +1,245 @@
+package travelRepo.domain.account.controller;
+
+import com.google.gson.Gson;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+import travelRepo.domain.account.dto.AccountModifyReq;
+import travelRepo.domain.account.entity.Account;
+import travelRepo.domain.account.repository.AccountRepository;
+import travelRepo.global.security.authentication.UserAccount;
+import travelRepo.global.security.jwt.JwtProcessor;
+import travelRepo.util.After;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Transactional
+@SpringBootTest
+@AutoConfigureMockMvc
+public class AccountCacheTest extends After {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private RedisTemplate<String, String> redisTemplate;
+
+    @Autowired
+    private Gson gson;
+
+    @Autowired
+    private AccountRepository accountRepository;
+
+    @Autowired
+    private JwtProcessor jwtProcessor;
+
+    @Test
+    @DisplayName("회원 조회 캐싱_성공")
+    void accountAddCache_Success() throws Exception {
+
+        //given
+        Long accountId = 10001L;
+        ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+
+        //when
+        ResultActions actions = mockMvc.perform(
+                get("/accounts/{accountId}", accountId)
+        );
+
+        String findAccount = valueOperations.get("findAccount::" + accountId);
+
+        //then
+        actions.andExpect(status().isOk());
+
+        assertThat(findAccount).isNotNull();
+    }
+
+    @Test
+    @DisplayName("회원 수정 캐싱 삭제_성공")
+    void accountModifyCache_Success() throws Exception {
+
+        //given
+        Long accountId = 10001L;
+        Long boardId1 = 12001L;
+        Long boardId2 = 12004L;
+        ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+        Account account = accountRepository.findById(accountId).get();
+        String jwt = "Bearer " + jwtProcessor.createAuthJwtToken(new UserAccount(account));
+
+        AccountModifyReq accountModifyReq = new AccountModifyReq();
+        accountModifyReq.setPassword("123456789");
+        accountModifyReq.setNickname("modifyTestNickname");
+        accountModifyReq.setIntro("modifyTestIntro");
+        accountModifyReq.setProfile("test/path");
+
+        String content = gson.toJson(accountModifyReq);
+
+        mockMvc.perform(
+                get("/accounts/{accountId}", accountId)
+        );
+        mockMvc.perform(
+                get("/boards/{boardId}", boardId1)
+        );
+        mockMvc.perform(
+                get("/boards/{boardId}", boardId2)
+        );
+
+        //when
+        ResultActions actions = mockMvc.perform(
+                post("/accounts/modify")
+                        .header("Authorization", jwt)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(content)
+        );
+
+        //then
+        String findAccount = valueOperations.get("findAccount::" + accountId);
+        String findBoard1 = valueOperations.get("findBoard::" + boardId1);
+        String findBoard2 = valueOperations.get("findBoard::" + boardId2);
+
+        actions.andExpect(status().isOk());
+        assertThat(findAccount).isNull();
+        assertThat(findBoard1).isNull();
+        assertThat(findBoard2).isNull();
+    }
+
+    @Test
+    @DisplayName("회원 수정 캐싱 삭제_실패")
+    void accountModifyCache_Fail() throws Exception {
+
+        //given
+        Long accountId = 10001L;
+        Long boardId1 = 12001L;
+        Long boardId2 = 12004L;
+        ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+        Account account = accountRepository.findById(accountId).get();
+        String jwt = "Bearer " + jwtProcessor.createAuthJwtToken(new UserAccount(account));
+
+        AccountModifyReq accountModifyReq = new AccountModifyReq();
+        accountModifyReq.setPassword("12");
+        accountModifyReq.setNickname("modifyTestNickname");
+        accountModifyReq.setIntro("modifyTestIntro");
+        accountModifyReq.setProfile("test/path");
+
+        String content = gson.toJson(accountModifyReq);
+
+        mockMvc.perform(
+                get("/accounts/{accountId}", accountId)
+        );
+        mockMvc.perform(
+                get("/boards/{boardId}", boardId1)
+        );
+        mockMvc.perform(
+                get("/boards/{boardId}", boardId2)
+        );
+
+        //when
+        ResultActions actions = mockMvc.perform(
+                post("/accounts/modify")
+                        .header("Authorization", jwt)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(content)
+        );
+
+        //then
+        String findAccount = valueOperations.get("findAccount::" + accountId);
+        String findBoard1 = valueOperations.get("findBoard::" + boardId1);
+        String findBoard2 = valueOperations.get("findBoard::" + boardId2);
+
+        actions.andExpect(status().isBadRequest());
+        assertThat(findAccount).isNotNull();
+        assertThat(findBoard1).isNotNull();
+        assertThat(findBoard2).isNotNull();
+    }
+
+    @Test
+    @DisplayName("회원 삭제 캐싱 삭제_성공")
+    void accountRemoveCache_Success() throws Exception {
+
+        //given
+        Long accountId = 10001L;
+        Long boardId1 = 12001L;
+        Long boardId2 = 12004L;
+        ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+        Account account = accountRepository.findById(accountId).get();
+        String jwt = "Bearer " + jwtProcessor.createAuthJwtToken(new UserAccount(account));
+
+        mockMvc.perform(
+                get("/accounts/{accountId}", accountId)
+        );
+        mockMvc.perform(
+                get("/boards/{boardId}", boardId1)
+        );
+        mockMvc.perform(
+                get("/boards/{boardId}", boardId2)
+        );
+
+        //when
+        ResultActions actions = mockMvc.perform(
+                delete("/accounts")
+                        .header("Authorization", jwt)
+        );
+
+        //then
+        String findAccount = valueOperations.get("findAccount::" + accountId);
+        String findBoard1 = valueOperations.get("findBoard::" + boardId1);
+        String findBoard2 = valueOperations.get("findBoard::" + boardId2);
+
+        actions.andExpect(status().isOk());
+        assertThat(findAccount).isNull();
+        assertThat(findBoard1).isNull();
+        assertThat(findBoard2).isNull();
+    }
+
+    @Test
+    @DisplayName("회원 삭제 캐싱 삭제_실패")
+    void accountRemoveCache_Fail() throws Exception {
+
+        //given
+        Long accountId = 10001L;
+        Long boardId1 = 12001L;
+        Long boardId2 = 12004L;
+        ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+        Account account = accountRepository.findById(accountId).get();
+        String jwt = "Bea " + jwtProcessor.createAuthJwtToken(new UserAccount(account));
+
+        mockMvc.perform(
+                get("/accounts/{accountId}", accountId)
+        );
+        mockMvc.perform(
+                get("/boards/{boardId}", boardId1)
+        );
+        mockMvc.perform(
+                get("/boards/{boardId}", boardId2)
+        );
+
+        //when
+        ResultActions actions = mockMvc.perform(
+                delete("/accounts")
+                        .header("Authorization", jwt)
+        );
+
+        //then
+        String findAccount = valueOperations.get("findAccount::" + accountId);
+        String findBoard1 = valueOperations.get("findBoard::" + boardId1);
+        String findBoard2 = valueOperations.get("findBoard::" + boardId2);
+
+        actions.andExpect(status().isUnauthorized());
+        assertThat(findAccount).isNotNull();
+        assertThat(findBoard1).isNotNull();
+        assertThat(findBoard2).isNotNull();
+    }
+}

--- a/back/src/test/java/travelRepo/domain/board/controller/BoardCacheTest.java
+++ b/back/src/test/java/travelRepo/domain/board/controller/BoardCacheTest.java
@@ -47,7 +47,7 @@ public class BoardCacheTest {
 
     @Test
     @DisplayName("게시물 단일 조회 캐싱_성공")
-    void boardAddCache_Success() throws Exception {
+    void boardDetailsCache_Success() throws Exception {
 
         // given
         Long boardId = 12001L;
@@ -169,9 +169,11 @@ public class BoardCacheTest {
 
         //then
         String findBoard = valueOperations.get("findBoard::" + boardId);
+        String boardView = valueOperations.get("boardView::" + boardId);
 
         actions.andExpect(status().isOk());
         assertThat(findBoard).isNull();
+        assertThat(boardView).isNull();
     }
 
     @Test
@@ -198,8 +200,10 @@ public class BoardCacheTest {
 
         //then
         String findBoard = valueOperations.get("findBoard::" + boardId);
+        String boardView = valueOperations.get("boardView::" + boardId);
 
         actions.andExpect(status().isUnauthorized());
         assertThat(findBoard).isNotNull();
+        assertThat(boardView).isNotNull();
     }
 }

--- a/back/src/test/java/travelRepo/domain/board/controller/BoardCacheTest.java
+++ b/back/src/test/java/travelRepo/domain/board/controller/BoardCacheTest.java
@@ -18,6 +18,7 @@ import travelRepo.domain.board.dto.BoardModifyReq;
 import travelRepo.domain.board.entity.Category;
 import travelRepo.global.security.authentication.UserAccount;
 import travelRepo.global.security.jwt.JwtProcessor;
+import travelRepo.util.After;
 
 import java.util.List;
 
@@ -28,7 +29,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @Transactional
 @SpringBootTest
 @AutoConfigureMockMvc
-public class BoardCacheTest {
+public class BoardCacheTest extends After {
 
     @Autowired
     private MockMvc mockMvc;

--- a/back/src/test/java/travelRepo/domain/board/controller/BoardCacheTest.java
+++ b/back/src/test/java/travelRepo/domain/board/controller/BoardCacheTest.java
@@ -1,0 +1,205 @@
+package travelRepo.domain.board.controller;
+
+import com.google.gson.Gson;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+import travelRepo.domain.account.entity.Account;
+import travelRepo.domain.account.repository.AccountRepository;
+import travelRepo.domain.board.dto.BoardModifyReq;
+import travelRepo.domain.board.entity.Category;
+import travelRepo.global.security.authentication.UserAccount;
+import travelRepo.global.security.jwt.JwtProcessor;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Transactional
+@SpringBootTest
+@AutoConfigureMockMvc
+public class BoardCacheTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private RedisTemplate<String, String> redisTemplate;
+
+    @Autowired
+    private Gson gson;
+
+    @Autowired
+    private AccountRepository accountRepository;
+
+    @Autowired
+    private JwtProcessor jwtProcessor;
+
+    @Test
+    @DisplayName("게시물 단일 조회 캐싱_성공")
+    void boardAddCache_Success() throws Exception {
+
+        // given
+        Long boardId = 12001L;
+        ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+
+        // when
+        ResultActions actions = mockMvc.perform(
+                get("/boards/{boardId}", boardId)
+        );
+
+        //then
+        String findBoard = valueOperations.get("findBoard::" + boardId);
+
+        actions.andExpect(status().isOk());
+        assertThat(findBoard).isNotNull();
+    }
+
+    @Test
+    @DisplayName("게시물 수정 캐싱 삭제_성공")
+    void boardModifyCache_Success() throws Exception {
+
+        //given
+        Long accountId = 10001L;
+        ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+        Account account = accountRepository.findById(accountId).get();
+        String jwt = "Bearer " + jwtProcessor.createAuthJwtToken(new UserAccount(account));
+
+        Long boardId = 12001L;
+
+        BoardModifyReq boardModifyReq = new BoardModifyReq();
+        boardModifyReq.setTitle("modified board title");
+        boardModifyReq.setContent("modified board content");
+        boardModifyReq.setLocation("modified board location");
+        boardModifyReq.setCategory(Category.RESTAURANT);
+        boardModifyReq.setTags(List.of("tag3", "tag2", "tag1"));
+        String content = gson.toJson(boardModifyReq);
+
+        mockMvc.perform(
+                get("/boards/{boardId}", boardId)
+        );
+
+        //when
+        ResultActions actions = mockMvc.perform(
+                multipart("/boards/{boardId}", boardId)
+                        .header("Authorization", jwt)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(content)
+        );
+
+        //then
+        String findBoard = valueOperations.get("findBoard::" + boardId);
+
+        actions.andExpect(status().isOk());
+        assertThat(findBoard).isNull();
+    }
+
+    @Test
+    @DisplayName("게시물 수정 캐싱 삭제_실패")
+    void boardModifyCache_Fail() throws Exception {
+
+        //given
+        Long accountId = 10001L;
+        ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+        Account account = accountRepository.findById(accountId).get();
+        String jwt = "Bearer " + jwtProcessor.createAuthJwtToken(new UserAccount(account));
+
+        Long boardId = 12001L;
+
+        BoardModifyReq boardModifyReq = new BoardModifyReq();
+        boardModifyReq.setTitle("m");
+        boardModifyReq.setContent("modified board content");
+        boardModifyReq.setLocation("modified board location");
+        boardModifyReq.setCategory(Category.RESTAURANT);
+        boardModifyReq.setTags(List.of("tag3", "tag2", "tag1"));
+        String content = gson.toJson(boardModifyReq);
+
+        mockMvc.perform(
+                get("/boards/{boardId}", boardId)
+        );
+
+        //when
+        ResultActions actions = mockMvc.perform(
+                multipart("/boards/{boardId}", boardId)
+                        .header("Authorization", jwt)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(content)
+        );
+
+        //then
+        String findBoard = valueOperations.get("findBoard::" + boardId);
+
+        actions.andExpect(status().isBadRequest());
+        assertThat(findBoard).isNotNull();
+    }
+
+    @Test
+    @DisplayName("게시물 삭제 캐싱 삭제_성공")
+    void boardRemoveCache_Success() throws Exception {
+
+        //given
+        Long accountId = 10001L;
+        ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+        Account account = accountRepository.findById(accountId).get();
+        String jwt = "Bearer " + jwtProcessor.createAuthJwtToken(new UserAccount(account));
+
+        Long boardId = 12001L;
+
+        mockMvc.perform(
+                get("/boards/{boardId}", boardId)
+        );
+
+        //when
+        ResultActions actions = mockMvc.perform(
+                delete("/boards/{boardId}", boardId)
+                        .header("Authorization", jwt)
+        );
+
+        //then
+        String findBoard = valueOperations.get("findBoard::" + boardId);
+
+        actions.andExpect(status().isOk());
+        assertThat(findBoard).isNull();
+    }
+
+    @Test
+    @DisplayName("게시물 삭제 캐싱 삭제_실패")
+    void boardRemoveCache_Fail() throws Exception {
+
+        //given
+        Long accountId = 10001L;
+        ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+        Account account = accountRepository.findById(accountId).get();
+        String jwt = "Bea " + jwtProcessor.createAuthJwtToken(new UserAccount(account));
+
+        Long boardId = 12001L;
+
+        mockMvc.perform(
+                get("/boards/{boardId}", boardId)
+        );
+
+        //when
+        ResultActions actions = mockMvc.perform(
+                delete("/boards/{boardId}", boardId)
+                        .header("Authorization", jwt)
+        );
+
+        //then
+        String findBoard = valueOperations.get("findBoard::" + boardId);
+
+        actions.andExpect(status().isUnauthorized());
+        assertThat(findBoard).isNotNull();
+    }
+}

--- a/back/src/test/java/travelRepo/util/After.java
+++ b/back/src/test/java/travelRepo/util/After.java
@@ -1,10 +1,16 @@
 package travelRepo.util;
 
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import travelRepo.global.cache.CacheProcessor;
 
 import java.io.File;
 
 public class After {
+
+    @Autowired
+    CacheProcessor cacheProcessor;
 
     @AfterAll
     static void deleteTestFolder() {
@@ -22,5 +28,10 @@ public class After {
             }
             file.delete();
         }
+    }
+
+    @BeforeEach
+    void flushRedis() {
+        cacheProcessor.flushRedis();
     }
 }


### PR DESCRIPTION
cache와 관련해서 서버구동중 발생하는 이벤트를 처리하는 Class인 cacheEvent를 생성했습니다.
서버가 시작될 때, 1시간마다 view를 업데이트하고 redis를 초기화하는 메서드를 해당 클래스에서 처리하도록 하였습니다.

추가적으로, cache와 관련된 test코드를 작성하였습니다. 회원 또는 게시물을 단일 조회 했을 때, 캐시가 잘 저장 되는지, 
수정과 삭제를 했을 때 관련된 캐시가 잘 삭제되는지를 테스트 하였습니다.

또한 모든 테스트 케이스마다 redis가 초기화되는 로직을 After 객체에 작성하였습니다.

추가 변경
1. 팔로우 회원 조회 시 회원이 작성한 게시물 수를 6개로 변경하였습니다.