### PR TITLE
[Fix] 팔로워,팔로잉 탭에서 유저카드 클릭시 userinfo가 갱신되지않는 현상 수정

### DIFF
--- a/front/src/component/userInfo/UserInfo.jsx
+++ b/front/src/component/userInfo/UserInfo.jsx
@@ -50,7 +50,7 @@ function UserInfo() {
         console.log(err);
         navigate('../../*');
       });
-  }, []);
+  }, [accountId]);
 
   return (
     <UserWrapper>


### PR DESCRIPTION
팔로워,팔로잉 탭에서 유저카드 클릭시 userinfo가 갱신되지않는 현상 수정
userInfo의 useEffect 종속성 배열에 accountId 가 추가되지 않아 발생하는 현상이였습니다.