### PR TITLE
[Feat] 사진 등록 미지원 확장자 차단 및 안내 메세지 추가

### DIFF
--- a/front/src/component/myInfoEdit/MyInfoEditProfile.jsx
+++ b/front/src/component/myInfoEdit/MyInfoEditProfile.jsx
@@ -104,6 +104,18 @@ function MyInfoEditProfile({ formData, setFormData }) {
     }
   };
 
+  const typeCheck = event => {
+    const targetFileType = event.target.files[0].type; // 업로드 파일 유형
+    const targetFileTypeShort = targetFileType.slice(
+      targetFileType.indexOf('/') + 1,
+      targetFileType.length,
+    ); // 확장자명 text추출
+    const onlyAccept = ['image/jpeg', 'image/png', 'image/jpg']; // 허용할 확장자명 설정
+    if (onlyAccept.indexOf(targetFileType) === -1) {
+      setErrorMessage(`${targetFileTypeShort} 형식은 업로드할 수 없습니다.`);
+    } else validatePhotos(event);
+  };
+
   // 미리보기 렌더링
   useEffect(() => {
     const reader = new FileReader();
@@ -149,7 +161,7 @@ function MyInfoEditProfile({ formData, setFormData }) {
           type="file"
           id="profile"
           name="profile"
-          onChange={validatePhotos}
+          onChange={typeCheck}
           onClick={handleClick}
           accept="image/png, image/jpg, image/jpeg"
         />

--- a/front/src/component/publish/PublishPhoto.jsx
+++ b/front/src/component/publish/PublishPhoto.jsx
@@ -235,7 +235,10 @@ const PublishPhoto = forwardRef(({ setPhotoUrl, deleteImages }, ref) => {
         )}
       </div>
       <div className="message">
-        업로드 가능한 파일 포맷은 jpg, jpeg, png입니다.
+        <span>
+          사진은 최대 5개까지 등록할 수 있으며, 지원하는 파일 형식은 jpg, jpeg,
+          png입니다.
+        </span>
       </div>
     </Container>
   );

--- a/front/src/component/publish/PublishPhoto.jsx
+++ b/front/src/component/publish/PublishPhoto.jsx
@@ -141,6 +141,18 @@ const PublishPhoto = forwardRef(({ setPhotoUrl, deleteImages }, ref) => {
     }
   };
 
+  const typeCheck = event => {
+    const targetFileType = event.target.files[0].type; // 업로드 파일 유형
+    const targetFileTypeShort = targetFileType.slice(
+      targetFileType.indexOf('/') + 1,
+      targetFileType.length,
+    ); // 확장자명 text추출
+    const onlyAccept = ['image/jpeg', 'image/png', 'image/jpg']; // 허용할 확장자명 설정
+    if (onlyAccept.indexOf(targetFileType) === -1) {
+      setErrorMessage(`${targetFileTypeShort} 형식은 업로드 할 수 없습니다.`);
+    } else validatePhotos(event);
+  };
+
   // 수정페이지 진입시 미리보기 불러오는 함수
   const preview = data => {
     return data.map(el => photos.push(el));
@@ -210,7 +222,7 @@ const PublishPhoto = forwardRef(({ setPhotoUrl, deleteImages }, ref) => {
             <input
               id="upload__button"
               type="file"
-              onChange={validatePhotos}
+              onChange={typeCheck}
               onClick={handleClick}
               accept="image/jpg, image/png, image/jpeg"
             />

--- a/front/src/component/publish/PublishPhoto.jsx
+++ b/front/src/component/publish/PublishPhoto.jsx
@@ -29,6 +29,7 @@ const Container = styled.section`
     width: 10rem;
     height: 10rem;
     border-radius: 1rem;
+    object-fit: cover;
   }
 
   .remove__button {

--- a/front/src/component/publish/PublishPhoto.jsx
+++ b/front/src/component/publish/PublishPhoto.jsx
@@ -149,7 +149,7 @@ const PublishPhoto = forwardRef(({ setPhotoUrl, deleteImages }, ref) => {
     ); // 확장자명 text추출
     const onlyAccept = ['image/jpeg', 'image/png', 'image/jpg']; // 허용할 확장자명 설정
     if (onlyAccept.indexOf(targetFileType) === -1) {
-      setErrorMessage(`${targetFileTypeShort} 형식은 업로드 할 수 없습니다.`);
+      setErrorMessage(`${targetFileTypeShort} 형식은 업로드할 수 없습니다.`);
     } else validatePhotos(event);
   };
 


### PR DESCRIPTION
Format을 "All files"로 하면 일부 확장자명(gif 등) 등록 가능했던 부분 막았습니다.
글작성,프로필사진에 적용했고 저는 webp, gif, bmp, avif 등 테스트 해봤는데 머지되면 한번씩 확인 부탁드릴게요

@hipopotamus 
<img width="529" alt="Screen Shot 2022-12-01 at 12 59 32 AM" src="https://user-images.githubusercontent.com/103170697/204847256-e5af294b-2e20-4aca-aa6d-d4055aa18530.png">
