### PR TITLE
[Fix] 썸네일 이미지 회전하는 현상 수정

### DIFF
--- a/back/build.gradle
+++ b/back/build.gradle
@@ -58,6 +58,9 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 
     implementation group: 'net.coobird', name: 'thumbnailator', version: '0.4.1'    /* thumbnailator */
+
+    implementation group: 'com.drewnoakes', name: 'metadata-extractor', version: '2.17.0'
+
 }
 
 tasks.named('test') {

--- a/back/src/main/java/travelRepo/global/image/repository/FolderImageRepository.java
+++ b/back/src/main/java/travelRepo/global/image/repository/FolderImageRepository.java
@@ -8,21 +8,19 @@ import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
-import java.util.UUID;
 
 @Repository
 @ConditionalOnProperty(value = "mod", havingValue = "local")
 public class FolderImageRepository implements ImageRepository {
 
     @Override
-    public String save(MultipartFile image, String path) throws IOException {
+    public String save(MultipartFile image, String filename, String path) throws IOException {
 
-        String localFilename = createLocalFilename(image);
-        String fullPath = path + localFilename;
+        String fullPath = path + filename;
 
         image.transferTo(new File(fullPath));
 
-        return "http://localhost:8080/image-files/" + localFilename;
+        return "http://localhost:8080/image-files/" + filename;
     }
 
     @Override
@@ -31,12 +29,6 @@ public class FolderImageRepository implements ImageRepository {
         File file = new File(path + fileName);
 
         return ImageIO.read(file);
-    }
-
-    private String createLocalFilename(MultipartFile image) {
-
-        int pos = image.getOriginalFilename().lastIndexOf(".");
-        return UUID.randomUUID() + image.getOriginalFilename().substring(pos);
     }
 }
 

--- a/back/src/main/java/travelRepo/global/image/repository/ImageRepository.java
+++ b/back/src/main/java/travelRepo/global/image/repository/ImageRepository.java
@@ -7,7 +7,7 @@ import java.io.IOException;
 
 public interface ImageRepository {
 
-    String save(MultipartFile image, String path) throws IOException;
+    String save(MultipartFile image, String fileName, String path) throws IOException;
 
     BufferedImage download(String fileName, String path) throws IOException;
 }

--- a/back/src/main/java/travelRepo/global/image/repository/S3ImageRepository.java
+++ b/back/src/main/java/travelRepo/global/image/repository/S3ImageRepository.java
@@ -4,8 +4,6 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.GetObjectRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.S3Object;
-import com.amazonaws.services.s3.model.S3ObjectInputStream;
-import com.amazonaws.util.IOUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -14,9 +12,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.util.UUID;
 
 @Repository
 @ConditionalOnProperty(value = "mod", havingValue = "server")
@@ -29,9 +25,9 @@ public class S3ImageRepository implements ImageRepository{
     private final AmazonS3 amazonS3;
 
     @Override
-    public String save(MultipartFile image, String path) throws IOException {
+    public String save(MultipartFile image, String filename, String path) throws IOException {
 
-        String s3Filename = path + createS3Filename(image);
+        String s3Filename = path + filename;
 
         ObjectMetadata objMeta = new ObjectMetadata();
         objMeta.setContentType(image.getContentType());
@@ -48,16 +44,8 @@ public class S3ImageRepository implements ImageRepository{
         String fullFileName = path + fileName;
 
         S3Object o = amazonS3.getObject(new GetObjectRequest(bucket, fullFileName));
-        S3ObjectInputStream objectInputStream = o.getObjectContent();
-        byte[] bytes = IOUtils.toByteArray(objectInputStream);
 
-        ByteArrayInputStream inputStream = new ByteArrayInputStream(bytes);
-        return ImageIO.read(inputStream);
-    }
+        return ImageIO.read(o.getObjectContent());
 
-    private String createS3Filename(MultipartFile image) {
-
-        int pos = image.getOriginalFilename().lastIndexOf(".");
-        return UUID.randomUUID() + image.getOriginalFilename().substring(pos);
     }
 }

--- a/back/src/main/java/travelRepo/global/image/service/ImageService.java
+++ b/back/src/main/java/travelRepo/global/image/service/ImageService.java
@@ -39,13 +39,8 @@ public class ImageService {
         try {
             metadata = ImageMetadataReader.readMetadata(image.getInputStream());
             directory = metadata.getFirstDirectoryOfType(ExifIFD0Directory.class);
-
-            if (directory != null) {
-                orientation = directory.getInt(ExifIFD0Directory.TAG_ORIENTATION);
-            }
-
+            orientation = directory.getInt(ExifIFD0Directory.TAG_ORIENTATION);
         } catch (Exception e) {
-            throw new BusinessLogicException(ExceptionCode.UPLOAD_FAILED);
         }
 
         String filename = orientation + createFilename(image);

--- a/back/src/main/java/travelRepo/global/image/service/ImageService.java
+++ b/back/src/main/java/travelRepo/global/image/service/ImageService.java
@@ -1,5 +1,9 @@
 package travelRepo.global.image.service;
 
+import com.drew.imaging.ImageMetadataReader;
+import com.drew.metadata.Directory;
+import com.drew.metadata.Metadata;
+import com.drew.metadata.exif.ExifIFD0Directory;
 import lombok.RequiredArgsConstructor;
 import net.coobird.thumbnailator.Thumbnails;
 import org.springframework.stereotype.Service;
@@ -10,10 +14,12 @@ import travelRepo.global.image.CustomMultipartFile;
 import travelRepo.global.image.repository.ImageRepository;
 
 import javax.imageio.ImageIO;
+import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 @Service
@@ -26,8 +32,26 @@ public class ImageService {
 
         validationImage(image);
 
+        Metadata metadata;
+        Directory directory;
+        int orientation = 1;
+
         try {
-            return imageRepository.save(image, path);
+            metadata = ImageMetadataReader.readMetadata(image.getInputStream());
+            directory = metadata.getFirstDirectoryOfType(ExifIFD0Directory.class);
+
+            if (directory != null) {
+                orientation = directory.getInt(ExifIFD0Directory.TAG_ORIENTATION);
+            }
+
+        } catch (Exception e) {
+            throw new BusinessLogicException(ExceptionCode.UPLOAD_FAILED);
+        }
+
+        String filename = orientation + createFilename(image);
+
+        try {
+            return imageRepository.save(image, filename, path);
         } catch (IOException e) {
             throw new BusinessLogicException(ExceptionCode.UPLOAD_FAILED);
         }
@@ -42,10 +66,19 @@ public class ImageService {
 
     public String getThumbnail(String imageAddress, String path) {
 
-        String fileName = imageAddress.substring(imageAddress.lastIndexOf("/") + 1);
+        String filename = imageAddress.substring(imageAddress.lastIndexOf("/") + 1);
+
+        int orientation = 1;
+
+        String imageId = filename.substring(0, filename.lastIndexOf("."));
+        if (imageId.length() > 36) {
+            orientation = imageId.charAt(0) - '0';
+        }
 
         try {
-            BufferedImage image = imageRepository.download(fileName, path);
+            BufferedImage image = imageRepository.download(filename, path);
+
+            image = rotateImage(image, orientation);
 
             if (image.getWidth() <= 510 && image.getHeight() <= 376) {
                 return imageAddress;
@@ -53,26 +86,65 @@ public class ImageService {
 
             BufferedImage thumbnail = Thumbnails.of(image).size(510, 376).asBufferedImage();
 
-            String address = uploadImage(convertBufferedImageToMultipartFile(thumbnail, fileName), path);
-
-            return address;
+            return uploadImage(convertBufferedImageToMultipartFile(thumbnail, filename), path);
 
         } catch (IOException e) {
             throw new BusinessLogicException(ExceptionCode.UPLOAD_FAILED);
         }
     }
 
-    private MultipartFile convertBufferedImageToMultipartFile(BufferedImage image, String fileName) throws IOException {
+    private MultipartFile convertBufferedImageToMultipartFile(BufferedImage image, String filename) throws IOException {
 
         ByteArrayOutputStream out = new ByteArrayOutputStream();
 
-        String contentType = fileName.substring(fileName.lastIndexOf(".") + 1);
+        String contentType = filename.substring(filename.lastIndexOf(".") + 1);
 
         ImageIO.write(image, contentType, out);
 
         byte[] bytes = out.toByteArray();
 
-        return new CustomMultipartFile(bytes, "image", fileName, contentType, bytes.length);
+        return new CustomMultipartFile(bytes, "image", filename, contentType, bytes.length);
+    }
+
+    private String createFilename(MultipartFile image) {
+
+        int pos = image.getOriginalFilename().lastIndexOf(".");
+        return UUID.randomUUID() + image.getOriginalFilename().substring(pos);
+    }
+
+    private BufferedImage rotateImage(BufferedImage image, int orientation) {
+
+        int width = image.getWidth();
+        int height = image.getHeight();
+        int type = image.getType();
+
+        BufferedImage newImage;
+        if (orientation == 6|| orientation == 8) {
+            newImage = new BufferedImage(height, width, type);
+        } else if (orientation == 3) {
+            newImage = new BufferedImage(width, height, type);
+        } else {
+            return image;
+        }
+
+        Graphics2D graphics = (Graphics2D) newImage.getGraphics();
+
+        switch (orientation) {
+            case 3:
+                graphics.rotate(Math.toRadians(180), width / 2, height / 2);
+                break;
+            case 6:
+                graphics.rotate(Math.toRadians(90), height / 2, width / 2);
+                graphics.translate((height - width) / 2, (width - height) / 2);
+                break;
+            case 8:
+                graphics.rotate(Math.toRadians(270), height / 2, width / 2);
+                graphics.translate((height - width) / 2, (width - height) / 2);
+                break;
+        }
+        graphics.drawImage(image, 0, 0, width, height, null);
+
+        return newImage;
     }
 
     public void validationImage(MultipartFile image) {


### PR DESCRIPTION
1. 썸네일 이미지 생성 시 이미지가 회전하는 현상을 수정했습니다.
 - 이미지 저장 시 사진의 메타 데이터에 있는 방향 정보(int)를 읽어와 파일명 앞에 추가했습니다.
 - 썸네일 이미지 생성 시 이 방향 정보를 통해 이미지를 올바른 방향으로 회전시킨 후 썸네일을 생성하도록 수정했습니다. 

2. S3ImageRepositody와 FolderImageRepository의 중복되는 로직을 ImageService로 이동시켰습니다. 