### PR TITLE
[Fix] 내정보수정 페이지 탈퇴버튼, 모달작동 수정

### DIFF
--- a/front/src/component/myInfoEdit/MyInfoEditContent.jsx
+++ b/front/src/component/myInfoEdit/MyInfoEditContent.jsx
@@ -90,6 +90,12 @@ function MyInfoEditContent({ formData, setFormData }) {
 
   const confirmModalCloser = () => {
     setConfirmModalOpened(false);
+    navigate(`/mypage/mypost/${accountId}`);
+    window.location.reload();
+  };
+
+  const openConfirmModal = () => {
+    setConfirmModalOpened(true);
   };
 
   const onChange = event => {
@@ -130,16 +136,12 @@ function MyInfoEditContent({ formData, setFormData }) {
     editUserApi(formData)
       .then(res => {
         if (res.status === 200) {
-          setConfirmModalOpened(true);
           setCookie('profile', formData.profile, {
             path: '/',
             sameSite: 'None',
             secure: 'false',
           });
-          setTimeout(() => {
-            navigate(`/mypage/mypost/${accountId}`);
-          }, 1000);
-          window.location.reload();
+          openConfirmModal();
         }
       })
       .catch(error => {

--- a/front/src/component/myInfoEdit/MyInfoEditDelete.jsx
+++ b/front/src/component/myInfoEdit/MyInfoEditDelete.jsx
@@ -10,13 +10,17 @@ import ConfirmModal from '../common/modal/ConfirmModal';
 import { removeCookie } from '../../util/cookie';
 import { loginActions } from '../../redux/loginSlice';
 
-const DeleteButton = styled(TransparentButton)`
-  color: var(--holder-base-color);
+const DeleteButtonWrapper = styled.div`
+  display: flex;
   flex: 1;
-  text-align: left;
+  align-items: center;
   @media screen and (max-width: 549px) {
     margin-left: 2rem;
   }
+`;
+
+const DeleteButton = styled(TransparentButton)`
+  color: var(--holder-base-color);
 `;
 
 const ReconfirmYesNoModal = styled(YesNoModal)``;
@@ -50,6 +54,20 @@ function MyinfoEditDelete() {
     setFarewellModalOpened(true);
   };
 
+  const closeFarewellModal = () => {
+    navigate('/');
+    toast('회원 탈퇴가 완료되었습니다.', {
+      position: 'top-right',
+      autoClose: 1000,
+      hideProgressBar: false,
+      closeOnClick: true,
+      pauseOnHover: false,
+      draggable: true,
+      progress: undefined,
+      theme: 'light',
+    });
+  };
+
   const closeConfirmModal = () => {
     setConfirmModalOpened(false);
     setReconfirmModalOpened(false);
@@ -75,20 +93,7 @@ function MyinfoEditDelete() {
         if (res.status === 200) {
           cookieRemover();
           openFarewellModal();
-          setTimeout(() => {
-            toast('회원 탈퇴가 완료되었습니다.', {
-              position: 'top-right',
-              autoClose: 1000,
-              hideProgressBar: false,
-              closeOnClick: true,
-              pauseOnHover: false,
-              draggable: true,
-              progress: undefined,
-              theme: 'light',
-            });
-            navigate('/');
-            dispatch(loginActions.logout());
-          }, 1000);
+          dispatch(loginActions.logout());
         }
       })
       .catch(error => {
@@ -98,9 +103,11 @@ function MyinfoEditDelete() {
 
   return (
     <>
-      <DeleteButton onClick={openConfirmModal}>
-        <small>회원탈퇴 &gt;</small>
-      </DeleteButton>
+      <DeleteButtonWrapper>
+        <DeleteButton onClick={openConfirmModal}>
+          <small>회원탈퇴 &gt;</small>
+        </DeleteButton>
+      </DeleteButtonWrapper>
       {confirmModalOpened ? (
         <YesNoModal
           modalMessage="회원 탈퇴를 진행하시겠습니까?"
@@ -125,7 +132,7 @@ function MyinfoEditDelete() {
       {farewellModalOpened ? (
         <FarewellModal
           modalMessage="이용해주셔서 감사합니다."
-          modalCloser={closeConfirmModal}
+          modalCloser={closeFarewellModal}
         />
       ) : null}
     </>


### PR DESCRIPTION
### 수정내역
- 회원탈퇴버튼 길이 css 재설정
- 탈퇴/수정완료때 뜨는 확인 모달 =>  확인을 눌러야 다음 페이지로 이동 (실제 동작은 모달 오픈 시키면서 이뤄짐)