### PR TITLE
[Feat] 마이페이지의 본문 데이터가 없는 경우

### DIFF
--- a/front/src/component/common/EmptyText.jsx
+++ b/front/src/component/common/EmptyText.jsx
@@ -2,6 +2,7 @@ import styled from 'styled-components';
 
 const EmptyTextBox = styled.div`
   display: flex;
+  align-items: center;
   font-size: 3rem;
   color: var(--holder-base-color);
   > span {

--- a/front/src/component/common/EmptyText.jsx
+++ b/front/src/component/common/EmptyText.jsx
@@ -1,0 +1,33 @@
+import styled from 'styled-components';
+
+const EmptyTextBox = styled.div`
+  display: flex;
+  font-size: 3rem;
+  color: var(--holder-base-color);
+  > span {
+    position: relative;
+    display: block;
+    width: 5rem;
+    height: 5rem;
+    border-radius: 50%;
+    border: 1px solid var(--holder-base-color);
+    margin-right: 1rem;
+    > svg {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+    }
+  }
+`;
+
+function EmptyText({ icon, text }) {
+  return (
+    <EmptyTextBox>
+      <span>{icon}</span>
+      <p>{text}</p>
+    </EmptyTextBox>
+  );
+}
+
+export default EmptyText;

--- a/front/src/component/common/Pagination.jsx
+++ b/front/src/component/common/Pagination.jsx
@@ -5,7 +5,6 @@ import { useEffect, useState } from 'react';
 
 const PageButtons = styled.div`
   display: flex;
-  margin-bottom: 20rem;
   > button {
     padding: 2px 1.4rem;
     margin: 0 3px;

--- a/front/src/component/follow/FollowList.jsx
+++ b/front/src/component/follow/FollowList.jsx
@@ -2,6 +2,7 @@ import styled from 'styled-components';
 import { BsCamera } from 'react-icons/bs';
 import FollowPost from './FollowPost';
 import FollowUserCard from './FollowUserCard';
+import EmptyText from '../common/EmptyText';
 
 const FollowListContainer = styled.div`
   display: flex;
@@ -31,26 +32,6 @@ const FollowListContainer = styled.div`
         width: 100%;
         display: flex;
         justify-content: center;
-        > div {
-          display: flex;
-          font-size: 3rem;
-          color: var(--holder-base-color);
-          > span {
-            position: relative;
-            display: block;
-            width: 5rem;
-            height: 5rem;
-            border-radius: 50%;
-            border: 1px solid var(--holder-base-color);
-            margin-right: 1rem;
-            > svg {
-              position: absolute;
-              top: 50%;
-              left: 50%;
-              transform: translate(-50%, -50%);
-            }
-          }
-        }
       }
     }
   }
@@ -79,12 +60,7 @@ function FollowList({ myFollowing }) {
             ))
           ) : (
             <li className="followList__empty">
-              <div>
-                <span>
-                  <BsCamera />
-                </span>
-                <p>스토리가 없습니다.</p>
-              </div>
+              <EmptyText icon={<BsCamera />} text="스토리가 없습니다." />
             </li>
           )}
         </ul>

--- a/front/src/component/follow/FollowList.jsx
+++ b/front/src/component/follow/FollowList.jsx
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import { BsCamera } from 'react-icons/bs';
 import FollowPost from './FollowPost';
 import FollowUserCard from './FollowUserCard';
 
@@ -25,6 +26,32 @@ const FollowListContainer = styled.div`
     flex: 1;
     > ul {
       display: flex;
+
+      .followList__empty {
+        width: 100%;
+        display: flex;
+        justify-content: center;
+        > div {
+          display: flex;
+          font-size: 3rem;
+          color: var(--holder-base-color);
+          > span {
+            position: relative;
+            display: block;
+            width: 5rem;
+            height: 5rem;
+            border-radius: 50%;
+            border: 1px solid var(--holder-base-color);
+            margin-right: 1rem;
+            > svg {
+              position: absolute;
+              top: 50%;
+              left: 50%;
+              transform: translate(-50%, -50%);
+            }
+          }
+        }
+      }
     }
   }
 
@@ -40,15 +67,26 @@ const FollowListContainer = styled.div`
 `;
 
 function FollowList({ myFollowing }) {
+  console.log(myFollowing.boards);
   return (
     <FollowListContainer>
       <FollowUserCard myFollowing={myFollowing} />
       <div className="followList__rightside">
         <ul className="followList__posts">
-          {myFollowing &&
+          {myFollowing.boards.length !== 0 ? (
             myFollowing.boards.map(board => (
               <FollowPost key={board.id} boards={board} />
-            ))}
+            ))
+          ) : (
+            <li className="followList__empty">
+              <div>
+                <span>
+                  <BsCamera />
+                </span>
+                <p>스토리가 없습니다.</p>
+              </div>
+            </li>
+          )}
         </ul>
       </div>
     </FollowListContainer>

--- a/front/src/component/follow/FollowUserCard.jsx
+++ b/front/src/component/follow/FollowUserCard.jsx
@@ -32,6 +32,8 @@ const FollowListLeftSide = styled.div`
     .followList__username {
       margin: 1rem 0 2rem;
       > a > p {
+        width: 12rem;
+        text-align: center;
         color: var(--font-base-black);
         font-size: 1.4rem;
         overflow: hidden;
@@ -58,6 +60,12 @@ const FollowListLeftSide = styled.div`
         width: 10rem;
         height: 10rem;
       }
+
+      .followList__username {
+        > a > p {
+          width: 10rem;
+        }
+      }
     }
   }
 
@@ -66,6 +74,11 @@ const FollowListLeftSide = styled.div`
       .followList__avatar {
         width: 9rem;
         height: 9rem;
+      }
+      .followList__username {
+        > a > p {
+          width: 9rem;
+        }
       }
     }
   }
@@ -80,10 +93,15 @@ const FollowListLeftSide = styled.div`
       .followList__avatar {
         width: 6rem;
         height: 6rem;
+        min-width: 6rem;
+        min-height: 6rem;
       }
       .followList__username {
-        padding-left: 1rem;
+        padding: 0 1rem;
         margin: 0;
+        > a > p {
+          width: auto;
+        }
       }
 
       .followList__button {

--- a/front/src/component/postDetail/PostDetailArticle.jsx
+++ b/front/src/component/postDetail/PostDetailArticle.jsx
@@ -4,6 +4,7 @@ import { toast } from 'react-toastify';
 import styled from 'styled-components';
 import { useNavigate } from 'react-router-dom';
 import uuid from 'react-uuid';
+import { GrMap } from 'react-icons/gr';
 import {
   postDetailDeleteApi,
   postDetailFollowApi,
@@ -118,6 +119,13 @@ const Body = styled.div`
   }
   .article__location {
     margin: 1rem 0;
+    display: flex;
+    align-items: center;
+    > svg {
+      width: 2rem;
+      height: 2rem;
+      margin-right: 5px;
+    }
   }
   .article__footer {
     flex-wrap: wrap;
@@ -333,7 +341,10 @@ function PostDetailArticle({ post, userLike, userFollow, self, board }) {
         <p className="article__header">{title}</p>
         <textarea value={content} className="article__content" disabled />
         {location ? (
-          <div className="article__location"> 위치 : {location}</div>
+          <div className="article__location">
+            <GrMap />
+            {location}
+          </div>
         ) : null}
         <div className="article__footer">
           <div className="footer__first">

--- a/front/src/component/userInfo/UserInfoCard.jsx
+++ b/front/src/component/userInfo/UserInfoCard.jsx
@@ -23,13 +23,25 @@ const UserInfoText = styled.div`
   justify-content: center;
   margin: 0 2rem;
   gap: 5px;
+
+  > div > h1,
+  > h5,
+  > p {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-line-clamp: 1;
+    -webkit-box-orient: vertical;
+    word-break: break-all;
+  }
+
   > div {
     display: flex;
     width: 100%;
     align-items: center;
     > h1 {
       margin-right: 2rem;
-      font-size: 2.4rem;
+      font-size: 2rem;
       font-weight: 500;
     }
   }
@@ -43,12 +55,6 @@ const UserInfoText = styled.div`
     text-align: start;
     font-size: 1.2rem;
     height: 2rem;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    display: -webkit-box;
-    -webkit-line-clamp: 1;
-    -webkit-box-orient: vertical;
-    word-break: break-all;
   }
 
   @media screen and (max-width: 549px) {

--- a/front/src/component/userInfo/UserInfoCard.jsx
+++ b/front/src/component/userInfo/UserInfoCard.jsx
@@ -21,7 +21,7 @@ const UserInfoText = styled.div`
   flex-direction: column;
   align-items: baseline;
   justify-content: center;
-  margin: 0 2rem;
+  margin-left: 2rem;
   gap: 5px;
 
   > div > h1,
@@ -44,6 +44,9 @@ const UserInfoText = styled.div`
       font-size: 2rem;
       font-weight: 500;
     }
+    > a {
+      min-width: 7rem;
+    }
   }
 
   > h5 {
@@ -62,7 +65,11 @@ const UserInfoText = styled.div`
 
     div {
       > h1 {
-        font-size: 2rem;
+        margin-right: 1rem;
+        font-size: 1.6rem;
+      }
+      > a {
+        min-width: 6rem;
       }
     }
 

--- a/front/src/pages/myPages/MyFollower.jsx
+++ b/front/src/pages/myPages/MyFollower.jsx
@@ -1,10 +1,12 @@
 import React, { useState, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import styled from 'styled-components';
+import { RiUserFollowLine } from 'react-icons/ri';
 import FollowList from '../../component/follow/FollowList';
 import followDataApi from '../../api/followDataApi';
 import Pagination from '../../component/common/Pagination';
 import LoadingSpinner from '../../component/common/LoadingSpinner';
+import EmptyText from '../../component/common/EmptyText';
 
 const MyPageMain = styled.main`
   padding-top: 22rem;
@@ -16,18 +18,40 @@ const MyPageMain = styled.main`
   .follower__container {
     width: 100%;
     max-width: 172rem;
-  }
 
-  .loading__container {
-    width: 100%;
-    display: flex;
-    justify-content: center;
-    padding-top: 1rem;
+    .loading__container {
+      width: 100%;
+      display: flex;
+      justify-content: center;
+      padding-top: 1rem;
+    }
+
+    .empty__follower {
+      width: 100%;
+      height: calc(100vh - 8rem - 22rem - 3rem - 10.1rem);
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      > div {
+        padding-bottom: 3rem;
+      }
+    }
   }
 
   @media screen and (max-width: 549px) {
     padding-top: 15.5rem;
     margin-bottom: 1rem;
+
+    .empty__follower {
+      height: calc(100vh - 8rem - 16.5rem - 16.6rem);
+      > div {
+        font-size: 2rem;
+        > span {
+          width: 4rem;
+          height: 4rem;
+        }
+      }
+    }
   }
 `;
 
@@ -60,6 +84,14 @@ function MyFollower() {
             myFollowing.map(following => (
               <FollowList key={following.id} myFollowing={following} />
             ))
+          )}
+          {!isPending && myFollowing.length === 0 && (
+            <div className="empty__follower">
+              <EmptyText
+                icon={<RiUserFollowLine />}
+                text="팔로워 회원이 없습니다."
+              />
+            </div>
           )}
         </section>
       </MyPageMain>

--- a/front/src/pages/myPages/MyFollower.jsx
+++ b/front/src/pages/myPages/MyFollower.jsx
@@ -63,7 +63,7 @@ function MyFollower() {
           )}
         </section>
       </MyPageMain>
-      {!isPending && (
+      {!isPending && myFollowing.length !== 0 && (
         <Pagination
           totalLists={totalLists}
           currentPage={currentPage}

--- a/front/src/pages/myPages/MyFollowing.jsx
+++ b/front/src/pages/myPages/MyFollowing.jsx
@@ -1,7 +1,9 @@
 import React, { useEffect, useState } from 'react';
+import { RiUserFollowLine } from 'react-icons/ri';
 import { useParams } from 'react-router-dom';
 import styled from 'styled-components';
 import followDataApi from '../../api/followDataApi';
+import EmptyText from '../../component/common/EmptyText';
 import LoadingSpinner from '../../component/common/LoadingSpinner';
 import Pagination from '../../component/common/Pagination';
 import FollowList from '../../component/follow/FollowList';
@@ -16,18 +18,40 @@ const MyPageMain = styled.main`
   .following__container {
     width: 100%;
     max-width: 172rem;
-  }
 
-  .loading__container {
-    width: 100%;
-    display: flex;
-    justify-content: center;
-    padding-top: 1rem;
+    .loading__container {
+      width: 100%;
+      display: flex;
+      justify-content: center;
+      padding-top: 1rem;
+    }
+
+    .empty__following {
+      width: 100%;
+      height: calc(100vh - 8rem - 22rem - 3rem - 10.1rem);
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      > div {
+        padding-bottom: 3rem;
+      }
+    }
   }
 
   @media screen and (max-width: 549px) {
     padding-top: 15.5rem;
     margin-bottom: 1rem;
+
+    .empty__following {
+      height: calc(100vh - 8rem - 16.5rem - 16.6rem);
+      > div {
+        font-size: 2rem;
+        > span {
+          width: 4rem;
+          height: 4rem;
+        }
+      }
+    }
   }
 `;
 
@@ -60,6 +84,14 @@ function MyFollowing() {
             myFollowing.map(following => (
               <FollowList key={following.id} myFollowing={following} />
             ))
+          )}
+          {!isPending && myFollowing.length === 0 && (
+            <div className="empty__following">
+              <EmptyText
+                icon={<RiUserFollowLine />}
+                text="팔로잉 회원이 없습니다."
+              />
+            </div>
           )}
         </section>
       </MyPageMain>

--- a/front/src/pages/myPages/MyFollowing.jsx
+++ b/front/src/pages/myPages/MyFollowing.jsx
@@ -63,7 +63,7 @@ function MyFollowing() {
           )}
         </section>
       </MyPageMain>
-      {!isPending && (
+      {!isPending && myFollowing.length !== 0 && (
         <Pagination
           totalLists={totalLists}
           currentPage={currentPage}

--- a/front/src/pages/myPages/MyLikes.jsx
+++ b/front/src/pages/myPages/MyLikes.jsx
@@ -1,9 +1,11 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
 import { useParams } from 'react-router-dom';
+import { HiOutlineHeart } from 'react-icons/hi';
 import Post from '../../component/common/Post';
 import useIntersect from '../../hooks/useIntersect';
 import LoadingSpinner from '../../component/common/LoadingSpinner';
+import EmptyText from '../../component/common/EmptyText';
 
 const MyPageMain = styled.main`
   padding-top: 23rem;
@@ -12,6 +14,28 @@ const MyPageMain = styled.main`
   display: flex;
   flex-wrap: wrap;
   width: 100%;
+
+  .empty__like {
+    width: 100%;
+    height: calc(100vh - 41.1rem);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    > div {
+      padding-bottom: 3rem;
+    }
+
+    @media screen and (max-width: 549px) {
+      height: calc(100vh - 8rem - 16.5rem - 16.6rem);
+      > div {
+        font-size: 2rem;
+        > span {
+          width: 4rem;
+          height: 4rem;
+        }
+      }
+    }
+  }
 
   .target {
     width: 100%;
@@ -55,7 +79,7 @@ const MyPageMain = styled.main`
 
 function MyLikes() {
   const [myLike, setMyLike] = useState([]);
-  const [isPending, setIsPending] = useState(false);
+  const [isPending, setIsPending] = useState(true);
   const { accountId } = useParams();
   const [target] = useIntersect(
     `/boards/like/account/${accountId}?`,
@@ -72,6 +96,14 @@ function MyLikes() {
       {myLike.map(like => {
         return <Post key={like.boardId} post={like} />;
       })}
+      {!isPending && myLike.length === 0 && (
+        <div className="empty__like">
+          <EmptyText
+            icon={<HiOutlineHeart />}
+            text="스토리에 좋아요를 해보세요."
+          />
+        </div>
+      )}
       <div ref={target} className="target">
         {isPending && <LoadingSpinner />}
       </div>

--- a/front/src/pages/myPages/MyLikes.jsx
+++ b/front/src/pages/myPages/MyLikes.jsx
@@ -22,7 +22,7 @@ const MyPageMain = styled.main`
     justify-content: center;
     align-items: center;
     > div {
-      padding-bottom: 3rem;
+      padding-bottom: 6rem;
     }
 
     @media screen and (max-width: 549px) {

--- a/front/src/pages/myPages/MyPost.jsx
+++ b/front/src/pages/myPages/MyPost.jsx
@@ -1,9 +1,11 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
 import { useParams } from 'react-router-dom';
+import { BsCamera } from 'react-icons/bs';
 import Post from '../../component/common/Post';
 import useIntersect from '../../hooks/useIntersect';
 import LoadingSpinner from '../../component/common/LoadingSpinner';
+import EmptyText from '../../component/common/EmptyText';
 
 const MyPageMain = styled.main`
   padding-top: 23rem;
@@ -12,6 +14,28 @@ const MyPageMain = styled.main`
   display: flex;
   flex-wrap: wrap;
   width: 100%;
+
+  .empty__post {
+    width: 100%;
+    height: calc(100vh - 41.1rem);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    > div {
+      padding-bottom: 3rem;
+    }
+
+    @media screen and (max-width: 549px) {
+      height: calc(100vh - 8rem - 16.5rem - 16.6rem);
+      > div {
+        font-size: 2rem;
+        > span {
+          width: 4rem;
+          height: 4rem;
+        }
+      }
+    }
+  }
 
   .target {
     width: 100%;
@@ -71,6 +95,11 @@ function MyPost() {
       {myPost.map(post => {
         return <Post key={post.boardId} post={post} />;
       })}
+      {!isPending && myPost.length === 0 && (
+        <div className="empty__post">
+          <EmptyText icon={<BsCamera />} text="스토리를 공유해보세요." />
+        </div>
+      )}
       <div ref={target} className="target">
         {isPending && <LoadingSpinner />}
       </div>

--- a/front/src/pages/myPages/MyPost.jsx
+++ b/front/src/pages/myPages/MyPost.jsx
@@ -79,7 +79,7 @@ const MyPageMain = styled.main`
 
 function MyPost() {
   const [myPost, setMyPost] = useState([]);
-  const [isPending, setIsPending] = useState(false);
+  const [isPending, setIsPending] = useState(true);
   const { accountId } = useParams();
   const [target] = useIntersect(
     `/boards/account/${accountId}?`,

--- a/front/src/pages/myPages/MyPost.jsx
+++ b/front/src/pages/myPages/MyPost.jsx
@@ -22,7 +22,7 @@ const MyPageMain = styled.main`
     justify-content: center;
     align-items: center;
     > div {
-      padding-bottom: 3rem;
+      padding-bottom: 6rem;
     }
 
     @media screen and (max-width: 549px) {


### PR DESCRIPTION
- 게시글, 좋아요, 팔로워, 팔로잉 페이지의 데이터가 없는 경우 해당하는 문구 표시
- 팔로워, 팔로잉 유저의 게시글이 없는 경우 해당하는 문구 표시
- 팔로워, 팔로잉 데이터가 업는 경우 페이지네이션 숨김
- 마이페이지 내 모든 컴포넌트의 nickname에 말줄임, 폰트 사이즈 조정, 너비 설정 등 css 수정