### PR TITLE
[Fix] 누락된 css 적용 및 수정

### DIFF
--- a/front/src/component/common/header/Header.jsx
+++ b/front/src/component/common/header/Header.jsx
@@ -30,7 +30,6 @@ const HeaderWrapper = styled.header`
 
   .header__logo {
     > h1 {
-      width: 20rem;
       height: 100%;
       display: flex;
       align-items: center;

--- a/front/src/component/common/header/HeaderUser.jsx
+++ b/front/src/component/common/header/HeaderUser.jsx
@@ -111,7 +111,7 @@ function HeaderUser() {
         }}
         className="header__write"
         fontSize="1.6rem"
-        width="9.5rem"
+        width="10rem"
         height="4.3rem"
         fontWeight="500"
       >

--- a/front/src/component/common/header/HeaderUser.jsx
+++ b/front/src/component/common/header/HeaderUser.jsx
@@ -15,7 +15,6 @@ const HeaderUserWrapper = styled.nav`
   height: 100%;
   display: flex;
   align-items: center;
-  min-width: 20rem;
   position: relative;
   .header__write {
     flex: 1;

--- a/front/src/component/postDetail/PostDetailArticle.jsx
+++ b/front/src/component/postDetail/PostDetailArticle.jsx
@@ -47,6 +47,7 @@ const Header = styled.div`
     height: 100%;
     border-radius: 50%;
     cursor: pointer;
+    object-fit: cover;
   }
   .writer__name {
     flex-basis: 60%;

--- a/front/src/component/postDetail/comment/CommentMore.jsx
+++ b/front/src/component/postDetail/comment/CommentMore.jsx
@@ -30,7 +30,7 @@ const MoreWrapper = styled.div`
     > img {
       cursor: pointer;
       border-radius: 50%;
-      object-fit: contain;
+      object-fit: cover;
     }
   }
   .comment__info {

--- a/front/src/component/postDetail/comment/CommentWrite.jsx
+++ b/front/src/component/postDetail/comment/CommentWrite.jsx
@@ -92,6 +92,9 @@ const WriteWrapper = styled.article`
       height: 5.5rem;
       right: 3rem;
     }
+    .comment__zero {
+      font-size: 1.4rem;
+    }
   }
 `;
 

--- a/front/src/pages/mainPages/MainPage.jsx
+++ b/front/src/pages/mainPages/MainPage.jsx
@@ -5,6 +5,8 @@ import FixedFooter from '../../component/common/footer/FixedFooter';
 
 const Main = styled.main`
   padding: 8rem 0 4rem;
+  display: flex;
+  justify-content: center;
   @media screen and (max-width: 549px) {
     padding-top: 6rem;
   }
@@ -25,26 +27,27 @@ const Main = styled.main`
 
   .main__wrapper {
     width: 100%;
+    max-width: 172rem;
     padding: 5rem 0 1rem;
     display: flex;
     justify-content: center;
     align-items: center;
     flex-direction: column;
+    margin: 0 2rem;
 
     @media screen and (max-width: 549px) {
       padding: 0;
       padding-top: 7.5rem;
+      margin: 0;
       .search__result {
         display: none;
       }
     }
 
     .main__container {
-      max-width: 172rem;
-      margin: 0 3rem;
+      width: 100%;
       display: flex;
       flex-wrap: wrap;
-      width: 100%;
 
       @media screen and (max-width: 1440px) {
         .post,

--- a/front/src/pages/myPages/MyLikes.jsx
+++ b/front/src/pages/myPages/MyLikes.jsx
@@ -8,7 +8,7 @@ import LoadingSpinner from '../../component/common/LoadingSpinner';
 import EmptyText from '../../component/common/EmptyText';
 
 const MyPageMain = styled.main`
-  padding-top: 23rem;
+  padding: 23rem 2rem 0;
   max-width: 172rem;
   margin: 0 3rem;
   display: flex;
@@ -69,7 +69,7 @@ const MyPageMain = styled.main`
 
   @media screen and (max-width: 549px) {
     margin: 0 1rem;
-    padding-top: 16.5rem;
+    padding: 16.5rem 0 0;
     .post,
     .post__skeleton {
       flex-basis: 100%;

--- a/front/src/pages/myPages/MyPost.jsx
+++ b/front/src/pages/myPages/MyPost.jsx
@@ -8,9 +8,9 @@ import LoadingSpinner from '../../component/common/LoadingSpinner';
 import EmptyText from '../../component/common/EmptyText';
 
 const MyPageMain = styled.main`
-  padding-top: 23rem;
-  max-width: 172rem;
-  margin: 0 3rem;
+  /* padding-top: 23rem; */
+  max-width: 175rem;
+  padding: 23rem 2rem 0;
   display: flex;
   flex-wrap: wrap;
   width: 100%;
@@ -68,7 +68,7 @@ const MyPageMain = styled.main`
   }
 
   @media screen and (max-width: 549px) {
-    padding-top: 16.5rem;
+    padding: 16.5rem 0 0;
     margin: 0 1rem;
     .post,
     .post__skeleton {


### PR DESCRIPTION
- 무한스크롤 적용 페이지들 좌우 여백이 적용되지 않고 있어서 수정했습니다.
- 게시글 상세페이지의 이미지들에 `object-fit: cover` 적용했습니다.
- 상세페이지 댓글창의 '댓글을 달아주세요' 텍스트에 549px이하일 때 font-size 조정했습니다.
- pc버전 로고에 불필요한 크기가 적용되어있어 수정했습니다.
- 게시글 작성 버튼에 적용된 크기가 `min-width` 때문에 적용되지 않고 있어서 수정했습니다.