### PR TITLE
[Feat] 구글 소셜로그인 추가

### DIFF
--- a/front/src/App.js
+++ b/front/src/App.js
@@ -14,6 +14,7 @@ import RestaurantPage from './pages/mainPages/RestaurantPage';
 import StayPage from './pages/mainPages/StayPage';
 import SpotPage from './pages/mainPages/SpotPage';
 import AllThemePage from './pages/mainPages/AllThemePage';
+import OauthPage from './pages/OauthPage';
 import MyPost from './pages/myPages/MyPost';
 import MyLikes from './pages/myPages/MyLikes';
 import MyFollower from './pages/myPages/MyFollower';
@@ -69,6 +70,7 @@ function App() {
           <Route path="myfollowing/:accountId" element={<MyFollowing />} />
           <Route path="myinfoedit/:accountId" element={<MyInfoEdit />} />
         </Route>
+        <Route path="/oauth" element={<OauthPage />} />
         <Route path="*" element={<NotFound />} />
       </Routes>
     </Suspense>

--- a/front/src/api/loginUserApi.js
+++ b/front/src/api/loginUserApi.js
@@ -11,16 +11,8 @@ const loginUserApi = async () => {
   });
 
   if (!accountId && !profile) {
-    localStorage.setItem('accountId', login.data.id, {
-      path: '/',
-      sameSite: 'None',
-      secure: 'false',
-    });
-    localStorage.setItem('profile', login.data.profile, {
-      path: '/',
-      sameSite: 'None',
-      secure: 'false',
-    });
+    localStorage.setItem('accountId', login.data.id);
+    localStorage.setItem('profile', login.data.profile);
   }
   return login;
 };

--- a/front/src/component/common/modal/LoginModal.jsx
+++ b/front/src/component/common/modal/LoginModal.jsx
@@ -120,7 +120,7 @@ function LoginModal() {
 
   // 구글 소셜 로그인
   const oauthHandler = () => {
-    window.location.assign(
+    window.location.replace(
       'http://ec2-13-125-238-70.ap-northeast-2.compute.amazonaws.com:8080/oauth2/authorization/google',
     );
   };

--- a/front/src/component/common/modal/LoginModal.jsx
+++ b/front/src/component/common/modal/LoginModal.jsx
@@ -202,9 +202,19 @@ function LoginModal() {
           <footer className="footer">
             <div className="footer__content">
               <div>
-                아직 회원이 아니신가요?{' '}
+                구글 계정으로 로그인
                 <TransparentButton
-                  fontSize="1.4rem"
+                  fontSize="1.3rem"
+                  onClick={signupModalOpener}
+                  margin="0 0 0 0.5rem"
+                >
+                  바로가기 &gt;
+                </TransparentButton>
+              </div>
+              <div>
+                아직 회원이 아니신가요?
+                <TransparentButton
+                  fontSize="1.3rem"
                   onClick={signupModalOpener}
                   margin="0 0 0 0.5rem"
                 >
@@ -212,9 +222,9 @@ function LoginModal() {
                 </TransparentButton>
               </div>
               <div>
-                비밀번호를 잊으셨나요?{' '}
+                비밀번호를 잊으셨나요?
                 <TransparentButton
-                  fontSize="1.4rem"
+                  fontSize="1.3rem"
                   onClick={findPasswordModalOpener}
                   margin="0 0 0 0.5rem"
                 >

--- a/front/src/component/common/modal/LoginModal.jsx
+++ b/front/src/component/common/modal/LoginModal.jsx
@@ -118,6 +118,13 @@ function LoginModal() {
     }
   }
 
+  // 구글 소셜 로그인
+  const oauthHandler = () => {
+    window.location.assign(
+      'http://ec2-13-125-238-70.ap-northeast-2.compute.amazonaws.com:8080/oauth2/authorization/google',
+    );
+  };
+
   // submit 버튼 클릭시 작동 함수
   const onSubmitHandler = e => {
     e.preventDefault();
@@ -205,7 +212,7 @@ function LoginModal() {
                 구글 계정으로 로그인
                 <TransparentButton
                   fontSize="1.3rem"
-                  onClick={signupModalOpener}
+                  onClick={oauthHandler}
                   margin="0 0 0 0.5rem"
                 >
                   바로가기 &gt;

--- a/front/src/pages/OauthPage.jsx
+++ b/front/src/pages/OauthPage.jsx
@@ -1,17 +1,25 @@
 import React, { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
+import { loginActions } from '../redux/loginSlice';
 import loginUserApi from '../api/loginUserApi';
 
 function OauthPage() {
-  useEffect(async () => {
+  const dispatch = useDispatch();
+  const oauthLogin = async () => {
     const url = new URL(window.location.href);
     const accessToken = url.searchParams.get('jwt');
     localStorage.setItem('accessToken', `Bearer ${accessToken}`);
     await loginUserApi()
-      .then(res => console.log(res))
-      .catch(err => console.log(err));
+      .then(() => {
+        dispatch(loginActions.login(true));
+      })
+      .catch(err => alert('로그인 실패', console.log(err)));
     window.location.replace('/');
-    console.log(url, accessToken);
-  }, []);
+  };
+  useEffect(() => {
+    oauthLogin();
+  }, [oauthLogin]);
+
   return <div>인증중입니다.</div>;
 }
 

--- a/front/src/pages/OauthPage.jsx
+++ b/front/src/pages/OauthPage.jsx
@@ -1,0 +1,18 @@
+import React, { useEffect } from 'react';
+import loginUserApi from '../api/loginUserApi';
+
+function OauthPage() {
+  useEffect(async () => {
+    const url = new URL(window.location.href);
+    const accessToken = url.searchParams.get('jwt');
+    localStorage.setItem('accessToken', `Bearer ${accessToken}`);
+    await loginUserApi()
+      .then(res => console.log(res))
+      .catch(err => console.log(err));
+    window.location.replace('/');
+    console.log(url, accessToken);
+  }, []);
+  return <div>인증중입니다.</div>;
+}
+
+export default OauthPage;


### PR DESCRIPTION
구글 소셜로그인 추가
로그인 모달에서 소셜로그인 버튼을 누르면 google oauth 페이지로 이동합니다.
google 인증을 완료하면 백엔드에서 클라이언트의 oauth 페이지로 리디렉션 시켜줍니다.
oauth 페이지에서 url에 있는 jwt를 쿠키에 저장하고, 로그인 유저조회 api를 실행하고, 로그인 상태를 true로 바꾼 뒤, 메인으로 이동시킵니다.