### PR TITLE
[Fix] 댓글 수정시 글자수 제한 및 로딩함수 위치 변경

### DIFF
--- a/front/src/component/postDetail/PostDetailMain.jsx
+++ b/front/src/component/postDetail/PostDetailMain.jsx
@@ -116,8 +116,9 @@ function PostDetailMain() {
           setLoading(false);
         })
         .catch(err => {
-          navigate('*');
-          console.log(err);
+          if (err.response.data.code === '009') {
+            navigate('*');
+          }
         });
     } else {
       postDetailApi(boardId.id)
@@ -131,8 +132,9 @@ function PostDetailMain() {
           setLoading(false);
         })
         .catch(err => {
-          navigate('*');
-          console.log(err);
+          if (err.response.data.code === '009') {
+            navigate('*');
+          }
         });
     }
   }, []);

--- a/front/src/component/postDetail/PostDetailPhoto.jsx
+++ b/front/src/component/postDetail/PostDetailPhoto.jsx
@@ -27,22 +27,7 @@ const Container = styled.div`
     left: calc(${props => props.count}* -100%);
 
     transition: all 500ms linear;
-    ${props => props.container}/* > img:nth-child(1) {
-      // first-child
-      left: 0%;
-    }
-    > img:nth-child(2) {
-      left: 100%;
-    }
-    > img:nth-child(3) {
-      left: 200%;
-    }
-    > img:nth-child(4) {
-      left: 300%;
-    }
-    > img:nth-child(5) {
-      left: 400%;
-    } */
+    ${props => props.container}
   }
   .dot__list {
     display: flex;

--- a/front/src/component/postDetail/comment/CommentMore.jsx
+++ b/front/src/component/postDetail/comment/CommentMore.jsx
@@ -8,7 +8,6 @@ import {
 
 const MoreWrapper = styled.div`
   width: 100%;
-  /* height: auto; */
   border-radius: var(--radius-10);
   border: 1px solid var(--font-base-grey);
   margin: 2rem auto;
@@ -48,7 +47,12 @@ const MoreWrapper = styled.div`
     > ul {
       display: flex;
       justify-content: space-between;
+      align-items: center;
+      > div {
+        margin-right: 3px;
+      }
       > li {
+        margin-left: 3px;
         cursor: pointer;
         color: var(--font-base-grey);
         &:hover {
@@ -142,6 +146,13 @@ function CommentMore({
               <ul>
                 {modifyFlag && (
                   <>
+                    <div
+                      className={
+                        modifyComment.length === 250 ? 'comment__max' : ''
+                      }
+                    >
+                      {modifyComment.length}/250
+                    </div>
                     <li
                       role="tab"
                       tabIndex={0}
@@ -197,6 +208,7 @@ function CommentMore({
             <input
               className="modify__input"
               value={modifyComment}
+              maxLength="250"
               onChange={e => setModifyComment(e.target.value)}
             />
           ) : (

--- a/front/src/component/postDetail/comment/CommentWrite.jsx
+++ b/front/src/component/postDetail/comment/CommentWrite.jsx
@@ -10,7 +10,7 @@ import {
 import CommentMore from './CommentMore';
 import { loginModalActions } from '../../../redux/loginModalSlice';
 import useInput from '../../../hooks/useInput';
-import debounce from '../../../util/debounce';
+// import debounce from '../../../util/debounce';
 import LoadingSpinner from '../../common/LoadingSpinner';
 
 const WriteWrapper = styled.article`
@@ -229,9 +229,9 @@ function CommentWrite() {
     }
   };
   // 디바운스 적용 댓글 등록 핸들러
-  const debounceSendHandler = debounce(() => {
-    commentSendHandler();
-  }, 200);
+  // const debounceSendHandler = debounce(() => {
+  //   commentSendHandler();
+  // }, 200);
 
   return (
     <WriteWrapper className="comment__write">
@@ -252,7 +252,8 @@ function CommentWrite() {
             onChange={setComment}
             onKeyUp={e => {
               if (e.code === 'Enter' && !commentLoading) {
-                debounceSendHandler();
+                commentSendHandler();
+                // debounceSendHandler();
               }
             }}
           />

--- a/front/src/component/postDetail/comment/CommentWrite.jsx
+++ b/front/src/component/postDetail/comment/CommentWrite.jsx
@@ -10,7 +10,7 @@ import {
 import CommentMore from './CommentMore';
 import { loginModalActions } from '../../../redux/loginModalSlice';
 import useInput from '../../../hooks/useInput';
-// import debounce from '../../../util/debounce';
+import debounce from '../../../util/debounce';
 import LoadingSpinner from '../../common/LoadingSpinner';
 
 const WriteWrapper = styled.article`
@@ -229,9 +229,9 @@ function CommentWrite() {
     }
   };
   // 디바운스 적용 댓글 등록 핸들러
-  // const debounceSendHandler = debounce(() => {
-  //   commentSendHandler();
-  // }, 200);
+  const debounceSendHandler = debounce(() => {
+    commentSendHandler();
+  }, 200);
 
   return (
     <WriteWrapper className="comment__write">
@@ -252,8 +252,7 @@ function CommentWrite() {
             onChange={setComment}
             onKeyUp={e => {
               if (e.code === 'Enter' && !commentLoading) {
-                commentSendHandler();
-                // debounceSendHandler();
+                debounceSendHandler();
               }
             }}
           />

--- a/front/src/component/postDetail/comment/CommentWrite.jsx
+++ b/front/src/component/postDetail/comment/CommentWrite.jsx
@@ -25,6 +25,9 @@ const WriteWrapper = styled.article`
     width: 100%;
     padding-bottom: 5px;
   }
+  .comment__max {
+    color: red;
+  }
   .comment__sticky {
     display: flex;
     flex-direction: column;
@@ -126,10 +129,11 @@ function CommentWrite() {
   // 무한 스크롤 데이터 요청 핸들러
   const commentListGetHandler = useCallback(
     board => {
+      setCommentLoading(true);
       postDetailCommentApi(board, lastData)
         .then(res => {
           const lastContent = res.content[res.content.length - 1];
-          setCommentLoading(true);
+
           setCommentList(prev => {
             return [...prev, ...res.content];
           });
@@ -139,11 +143,11 @@ function CommentWrite() {
               `lastCommentId=${lastContent.commentId}&lastCommentCreatedAt=${lastContent.createdAt}`,
             );
           }
-          setCommentLoading(false);
         })
         .catch(err => {
           console.log(err);
         });
+      setCommentLoading(false);
     },
     [lastData],
   );
@@ -194,9 +198,9 @@ function CommentWrite() {
   // 댓글 작성 핸들러
   const commentSendHandler = () => {
     if (modalOpenHandler() && comment !== '') {
+      setCommentLoading(true);
       postDetailCommentSubmitApi(boardId.id, comment)
         .then(() => {
-          setCommentLoading(true);
           setHasNext(true);
           setPage(0);
           setLastData('');
@@ -216,12 +220,12 @@ function CommentWrite() {
             progress: undefined,
             theme: 'light',
           });
-          setCommentLoading(false);
         })
         .catch(err => {
           // toast
           console.log(err);
         });
+      setCommentLoading(false);
     }
   };
   // 디바운스 적용 댓글 등록 핸들러
@@ -232,7 +236,13 @@ function CommentWrite() {
   return (
     <WriteWrapper className="comment__write">
       <div className="comment__sticky">
-        <div className="comment__couunt">{comment.length}/250</div>
+        <div
+          className={`comment__couunt ${
+            comment.length === 250 ? 'comment__max' : ''
+          }`}
+        >
+          {comment.length}/250
+        </div>
         <div className="comment__form">
           <input
             className="comment__input"
@@ -241,7 +251,7 @@ function CommentWrite() {
             value={comment}
             onChange={setComment}
             onKeyUp={e => {
-              if (e.code === 'Enter') {
+              if (e.code === 'Enter' && !commentLoading) {
                 debounceSendHandler();
               }
             }}
@@ -249,7 +259,9 @@ function CommentWrite() {
           <button
             className="comment__button"
             onClick={() => {
-              commentSendHandler();
+              if (!commentLoading) {
+                commentSendHandler();
+              }
             }}
           >
             등록


### PR DESCRIPTION
### 작업목록
1. 댓글 수정시 글자수 표시
2. 댓글 250자를 전부 작성시 빨간색으로 강조 표시
3. 로딩 함수 위치 변경
4. 게시물이 존재하지 않을 경우에만 에러 페이지로 이동
5. 댓글 입력시 전송 중일 경우에는 다시 전송을 못하도록 막음